### PR TITLE
some cmdlets missing in pds1 config

### DIFF
--- a/build/Eryph.ComputeClient.psd1
+++ b/build/Eryph.ComputeClient.psd1
@@ -72,7 +72,15 @@ RequiredModules = @()
 FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = @("Get-EryphMachine", "New-EryphMachine", "Remove-EryphMachine", "Set-EryphMachine", "Start-EryphMachine", "Stop-EryphMachine")
+CmdletsToExport = @(
+    "Get-EryphMachine", 
+    "New-EryphMachine", 
+    "Remove-EryphMachine", 
+    "Update-EryphMachine", 
+    "Start-EryphMachine", 
+    "Stop-EryphMachine", 
+    "Get-EryphVM", 
+    "Get-EryphVirtualDisk")
 
 # Variables to export from this module
 VariablesToExport = '*'


### PR DESCRIPTION
Get-EryphVM
Get-EryphVirtualDisk
Update-EryphMachine

are not in psd1 and therefore not visible from installed module.