### PR TITLE
Variables in fodder content

### DIFF
--- a/src/Eryph.ComputeClient.Commands/Catlets/CatletConfigCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/CatletConfigCmdlet.cs
@@ -76,13 +76,14 @@ namespace Eryph.ComputeClient.Commands.Catlets
             {
                 var choices = new Collection<ChoiceDescription>()
                 {
-                    new("&Yes"),
-                    new("&No"),
+                    new("&Yes", "You will be asked to provide values for all variables."),
+                    new("&No", "You will not be asked for any values."),
                 };
 
                 if(anyRequired)
                 {
-                    choices.Add(new ChoiceDescription("&Required only"));
+                    choices.Add(new ChoiceDescription("&Required only",
+                        "You will only be asked for the values of variables which are required and do not have a value yet."));
                 }
 
                 // The prompt for choice will fail when the Powershell session
@@ -142,7 +143,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
                 if (IsValueValid(config, result))
                     return result;
 
-                Host.UI.WriteLine($"The provided value is invalid. Please try again.");
+                Host.UI.WriteLine("The provided value is invalid. Please try again.");
             }
         }
 

--- a/src/Eryph.ComputeClient.Commands/Catlets/CatletConfigCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/CatletConfigCmdlet.cs
@@ -1,9 +1,13 @@
-﻿using Eryph.ConfigModel.Json;
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using Eryph.ConfigModel.Json;
 using Eryph.ConfigModel.Catlets;
+using Eryph.ConfigModel.Variables;
 using Eryph.ConfigModel.Yaml;
 using YamlDotNet.Core;
-using static Org.BouncyCastle.Math.EC.ECCurve;
-using System.Text.RegularExpressions;
 
 namespace Eryph.ComputeClient.Commands.Catlets
 {
@@ -30,5 +34,57 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
         }
 
+        protected void PopulateVariables(CatletConfig catletConfig)
+        {
+            if (catletConfig.Variables is not { Length: > 0 })
+                return;
+
+            var fieldDescriptions = catletConfig.Variables.Select(v =>
+            {
+                var fieldDescription = new FieldDescription(v.Name)
+                {
+                    IsMandatory = v.Required.GetValueOrDefault(),
+                    DefaultValue = v.Value is not null ? new PSObject(v.Value) : null,
+                };
+                fieldDescription.SetParameterType(GetType(v.Type.GetValueOrDefault(VariableType.String)));
+                return fieldDescription;
+            }).ToList();
+
+            try
+            {
+                var results = Host.UI.Prompt(
+                    "Catlet Parameters",
+                    "Please provide values for catlet parameters",
+                    new Collection<FieldDescription>(fieldDescriptions));
+
+                foreach (var result in results)
+                {
+                    var variable = catletConfig.Variables.FirstOrDefault(v => v.Name == result.Key);
+                    if (variable is not null)
+                    {
+                        variable.Value = result.Value.ToString();
+                    }
+                }
+            }
+            // TODO proper exception type
+            catch (Exception ex)
+            {
+                // The prompt will fail if the Powershell session is not
+                // interactive. Unfortunately, there is no easy way to
+                // reliably detect a non-interactive session. Hence, we
+                // just catch the exception and continue.
+            }
+        }
+
+        private static Type GetType(VariableType variableType) =>
+        variableType switch
+        {
+            VariableType.String => typeof(string),
+            VariableType.Number => typeof(decimal),
+            VariableType.Boolean => typeof(bool),
+            _ => throw new ArgumentException(
+                $"The variable type {variableType} is not supported.",
+                nameof(variableType))
+        };
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/CatletConfigCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/CatletConfigCmdlet.cs
@@ -37,13 +37,16 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
         }
 
-        protected void PopulateVariables(CatletConfig catletConfig, Hashtable variables)
+        protected void PopulateVariables(CatletConfig catletConfig, Hashtable variables, bool skipVariablesPrompt)
         {
             if (catletConfig.Variables is not { Length: > 0 })
                 return;
 
             ApplyVariablesFromParameter(catletConfig.Variables, variables);
-            ReadVariablesFromInput(catletConfig.Variables);
+            if (!skipVariablesPrompt)
+            {
+                ReadVariablesFromInput(catletConfig.Variables);
+            }
         }
 
         private static void ApplyVariablesFromParameter(VariableConfig[] variableConfigs, Hashtable variables)

--- a/src/Eryph.ComputeClient.Commands/Catlets/NewCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/NewCatletCommand.cs
@@ -95,6 +95,8 @@ namespace Eryph.ComputeClient.Commands.Catlets
             if (!string.IsNullOrWhiteSpace(Name))
                 config.Name = Name;
 
+            PopulateVariables(config);
+
             var serializedConfig = JsonSerializer.SerializeToElement(config, ConfigModelJsonSerializer.DefaultOptions);
 
             WaitForOperation(

--- a/src/Eryph.ComputeClient.Commands/Catlets/NewCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/NewCatletCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Management.Automation;
 using System.Text;
 using System.Text.Json;
@@ -48,6 +49,9 @@ namespace Eryph.ComputeClient.Commands.Catlets
         [ValidateNotNullOrEmpty]
         public string Name { get; set; }
 
+        [Parameter]
+        public Hashtable Variables { get; set; }
+
         private bool _noWait;
         private StringBuilder _input = new StringBuilder();
 
@@ -95,7 +99,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             if (!string.IsNullOrWhiteSpace(Name))
                 config.Name = Name;
 
-            PopulateVariables(config);
+            PopulateVariables(config, Variables);
 
             var serializedConfig = JsonSerializer.SerializeToElement(config, ConfigModelJsonSerializer.DefaultOptions);
 

--- a/src/Eryph.ComputeClient.Commands/Catlets/NewCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/NewCatletCommand.cs
@@ -52,6 +52,9 @@ namespace Eryph.ComputeClient.Commands.Catlets
         [Parameter]
         public Hashtable Variables { get; set; }
 
+        [Parameter]
+        public SwitchParameter SkipVariablesPrompt { get; set; }
+
         private bool _noWait;
         private StringBuilder _input = new StringBuilder();
 
@@ -99,7 +102,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             if (!string.IsNullOrWhiteSpace(Name))
                 config.Name = Name;
 
-            PopulateVariables(config, Variables);
+            PopulateVariables(config, Variables, SkipVariablesPrompt);
 
             var serializedConfig = JsonSerializer.SerializeToElement(config, ConfigModelJsonSerializer.DefaultOptions);
 

--- a/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
@@ -48,8 +48,6 @@ namespace Eryph.ComputeClient.Commands.Catlets
                         JsonSerializer.SerializeToElement(config)))
                     , _nowait, true);
             }
-
         }
-
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
@@ -36,13 +36,16 @@ namespace Eryph.ComputeClient.Commands.Catlets
         [Parameter]
         public Hashtable Variables { get; set; }
 
+        [Parameter]
+        public SwitchParameter SkipVariablesPrompt { get; set; }
+
         protected override void ProcessRecord()
         {
             foreach (var id in Id)
             {
                 var config = DeserializeConfigString(Config);
 
-                PopulateVariables(config, Variables);
+                PopulateVariables(config, Variables, SkipVariablesPrompt);
 
                 WaitForOperation(Factory.CreateCatletsClient().Update(id, new UpdateCatletRequestBody(Guid.NewGuid(),
                         JsonSerializer.SerializeToElement(config)))

--- a/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Management.Automation;
 using System.Text.Json;
 using Eryph.ClientRuntime;
@@ -32,12 +33,17 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
         private bool _nowait;
 
+        [Parameter]
+        public Hashtable Variables { get; set; }
 
         protected override void ProcessRecord()
         {
             foreach (var id in Id)
             {
                 var config = DeserializeConfigString(Config);
+
+                PopulateVariables(config, Variables);
+
                 WaitForOperation(Factory.CreateCatletsClient().Update(id, new UpdateCatletRequestBody(Guid.NewGuid(),
                         JsonSerializer.SerializeToElement(config)))
                     , _nowait, true);

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.4.0" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.4.0" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.4.1-PullRequest0076.7" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.4.1-PullRequest0076.7" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.1-PullRequest0076.7" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.4.1-PullRequest0076.7" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.4.1-PullRequest0076.7" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.1-PullRequest0076.7" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.4.1-PullRequest0076.10" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.4.1-PullRequest0076.10" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.1-PullRequest0076.10" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.4.1-PullRequest0076.14" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.4.1-PullRequest0076.14" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.1-PullRequest0076.14" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.4.1-PullRequest0076.16" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.4.1-PullRequest0076.16" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.1-PullRequest0076.16" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.4.1-PullRequest0076.10" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.4.1-PullRequest0076.10" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.1-PullRequest0076.10" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.4.1-PullRequest0076.14" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.4.1-PullRequest0076.14" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.1-PullRequest0076.14" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.4.1-PullRequest0076.16" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.4.1-PullRequest0076.16" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.1-PullRequest0076.16" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.5.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.5.0" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.5.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This PR adds support for variables in the fodder content. `New-Catlet` and `Update-Catlet` can be provided variables with the parameter `-Variables ` which accepts a `Hashtable`. Additionally, the Cmdlets will query the user for the variables when they are executed in an interactive session.