### PR TITLE
Add Cmdlet to remove catlet disks

### DIFF
--- a/build/Eryph.ComputeClient.psd1
+++ b/build/Eryph.ComputeClient.psd1
@@ -79,8 +79,9 @@ CmdletsToExport = @(
     "Update-Catlet", 
     "Start-Catlet", 
     "Stop-Catlet", 
-    "Get-Catlet", 
-    "Get-CatletIp", 
+    "Get-CatletIp",
+    "Get-CatletDisk",
+    "Remove-CatletDisk"
     "Get-EryphOperation",
     "Get-VNetwork",
     "Set-VNetwork",

--- a/src/Eryph.ComputeClient.Commands/Catlets/CatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/CatletDiskCmdlet.cs
@@ -14,11 +14,11 @@ public abstract class CatletDiskCmdlet : ComputeCmdLet
         return Factory.CreateVirtualDisksClient().Get(id);
     }
 
-    protected void WaitForOperation(Operation operation, bool noWait, bool alwaysWriteNetwork, string knownCatletDiskId = default)
+    protected void WaitForOperation(Operation operation, bool noWait, bool alwaysWriteCatletDisk, string knownCatletDiskId = default)
     {
         if (noWait)
         {
-            if (knownCatletDiskId == default || !alwaysWriteNetwork)
+            if (knownCatletDiskId == default || !alwaysWriteCatletDisk)
                 WriteObject(operation);
             else
                 WriteObject(GetSingleCatletDisk(knownCatletDiskId));

--- a/src/Eryph.ComputeClient.Commands/Catlets/CatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/CatletDiskCmdlet.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Eryph.ComputeClient.Models;
+
+namespace Eryph.ComputeClient.Commands.Catlets;
+
+public abstract class CatletDiskCmdlet : ComputeCmdLet
+{
+    protected VirtualDisk GetSingleCatletDisk(string id)
+    {
+        return Factory.CreateVirtualDisksClient().Get(id);
+    }
+
+    protected void WaitForOperation(Operation operation, bool noWait, bool alwaysWriteNetwork, string knownCatletDiskId = default)
+    {
+        if (noWait)
+        {
+            if (knownCatletDiskId == default || !alwaysWriteNetwork)
+                WriteObject(operation);
+            else
+                WriteObject(GetSingleCatletDisk(knownCatletDiskId));
+            return;
+        }
+
+        WaitForOperation(operation, (op) => ResourceWriter(op, Write));
+        return;
+
+        void Write(ResourceType resourceType, string id)
+        {
+            if (resourceType == ResourceType.VirtualDisk)
+                WriteObject(GetSingleCatletDisk(id));
+        }
+    }
+}

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
@@ -2,37 +2,41 @@
 using Eryph.ComputeClient.Models;
 using JetBrains.Annotations;
 
-namespace Eryph.ComputeClient.Commands.Catlets
+namespace Eryph.ComputeClient.Commands.Catlets;
+
+[PublicAPI]
+[Cmdlet(VerbsCommon.Get, "CatletDisk", DefaultParameterSetName = "get")]
+[OutputType(typeof(Catlet), ParameterSetName = ["get"])]
+[OutputType(typeof(Catlet), ParameterSetName = ["list"])]
+public class GetCatletDiskCommand : CatletDiskCmdlet
 {
-    [PublicAPI]
-    [Cmdlet(VerbsCommon.Get, "CatletDisk", DefaultParameterSetName = "get")]
-    [OutputType(typeof(VirtualDisk))]
-    public class GetCatletDiskCommand : ComputeCmdLet
+    [Parameter(
+        ParameterSetName = "get",
+        Position = 0,
+        ValueFromPipeline = true,
+        ValueFromPipelineByPropertyName = true)]
+    public string[] Id { get; set; }
+
+    [Parameter(
+        ParameterSetName = "list",
+        ValueFromPipeline = true,
+        ValueFromPipelineByPropertyName = true)]
+    [ValidateNotNullOrEmpty]
+    public string ProjectName { get; set; }
+
+    protected override void ProcessRecord()
     {
-        [Parameter(
-            ParameterSetName = "get",
-            Position = 0,
-            ValueFromPipeline = true,
-            ValueFromPipelineByPropertyName = true)]
-        public string[] Id { get; set; }
-
-        protected override void ProcessRecord()
+        if (Id != null)
         {
-            if (Id != null)
+            foreach (var id in Id)
             {
-                foreach (var id in Id)
-                {
-                    WriteObject(Factory.CreateVirtualDisksClient().Get(id));
-                }
-
-                return;
+                WriteObject(GetSingleCatletDisk(id));
             }
 
-            ListOutput(Factory.CreateVirtualDisksClient().List());
-
-
+            return;
         }
 
+        var projectId = GetProjectId(ProjectName);
+        ListOutput(Factory.CreateVirtualDisksClient().List(projectId: projectId));
     }
-
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
@@ -64,7 +64,7 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
                 continue;
             }
 
-            WaitForOperation(Factory.CreateVirtualDisksClient().Delete(id).Value, NoWait.IsPresent, false, id);
+            WaitForOperation(Factory.CreateVirtualDisksClient().Delete(id).Value, NoWait, false, id);
 
             if (PassThru)
                 WriteObject(virtualDisk);

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using System.Threading.Tasks;
+using Eryph.ComputeClient.Models;
+using JetBrains.Annotations;
+
+namespace Eryph.ComputeClient.Commands.Catlets;
+
+[PublicAPI]
+[Cmdlet(VerbsCommon.Remove, "CatletDisk")]
+[OutputType(typeof(Operation), typeof(VirtualDisk))]
+public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
+{
+    [Parameter(
+        Position = 0,
+        ValueFromPipeline = true,
+        Mandatory = true,
+        ValueFromPipelineByPropertyName = true)]
+    public string[] Id { get; set; }
+
+    /// <summary>
+    /// This parameter overrides the ShouldContinue call to force
+    /// the cmdlet to stop its operation. This parameter should always
+    /// be used with caution.
+    /// </summary>
+    [Parameter]
+    public SwitchParameter Force { get; set; }
+
+    /// <summary>
+    /// This parameter indicates that the cmdlet should return
+    /// an object to the pipeline after the processing has been
+    /// completed.
+    /// </summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
+    [Parameter]
+    public SwitchParameter NoWait { get; set; }
+
+    private bool _yesToAll;
+    private bool _noToAll;
+
+    protected override void ProcessRecord()
+    {
+        foreach (var id in Id)
+        {
+            VirtualDisk virtualDisk;
+            try
+            {
+                virtualDisk = Factory.CreateVirtualDisksClient().Get(id);
+            }
+            catch (Exception ex)
+            {
+                WriteError(new ErrorRecord(ex, "CatletDiskNotFound", ErrorCategory.ObjectNotFound, id));
+                continue;
+            }
+
+            if (!Force && !ShouldContinue($"Catlet disk '{virtualDisk.Name}' (Id:{id}) will be deleted!", "Warning!",
+                    ref _yesToAll, ref _noToAll))
+            {
+                continue;
+            }
+
+            WaitForOperation(Factory.CreateVirtualDisksClient().Delete(id).Value, NoWait.IsPresent, false, id);
+
+            if (PassThru)
+                WriteObject(virtualDisk);
+        }
+    }
+}


### PR DESCRIPTION
Add a dedicated Cmdlet `Remove-CatletDisk` which can be used to separately delete a virtual hard disk.