### PR TITLE
Add confirmation when deleting projects

### DIFF
--- a/src/Eryph.ComputeClient.Commands/Projects/RemoveProjectCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Projects/RemoveProjectCommand.cs
@@ -41,7 +41,7 @@ public class RemoveProjectCommand : ProjectCmdlet
                 continue;
             }
 
-            if (!Force && !ShouldContinue($"Project '{project.Name}' (Id:{id}) will be deleted!", "Warning!",
+            if (!Force && !ShouldContinue($"Project '{project.Name}' (Id:{id}) and all catlets in the project will be deleted!", "Warning!",
                     ref _yesToAll, ref _noToAll))
             {
                 continue;

--- a/src/Eryph.ComputeClient.Commands/Projects/RemoveProjectCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Projects/RemoveProjectCommand.cs
@@ -1,42 +1,53 @@
 ﻿using System;
 using System.Management.Automation;
-using Eryph.ClientRuntime;
 using Eryph.ComputeClient.Models;
 using JetBrains.Annotations;
 
-namespace Eryph.ComputeClient.Commands.Projects
+namespace Eryph.ComputeClient.Commands.Projects;
+
+[PublicAPI]
+[Cmdlet(VerbsCommon.Remove, "EryphProject")]
+[OutputType(typeof(Operation))]
+public class RemoveProjectCommand : ProjectCmdlet
 {
-    [PublicAPI]
-    [Cmdlet(VerbsCommon.Remove, "EryphProject")]
-    [OutputType(typeof(Operation))]
-    public class RemoveProjectCommand : ProjectCmdlet
+    [Parameter(
+        Position = 0,
+        ValueFromPipeline = true,
+        Mandatory = true,
+        ValueFromPipelineByPropertyName = true)]
+    public string[] Id { get; set; }
+
+    [Parameter]
+    public SwitchParameter Force { get; set; }
+
+    [Parameter]
+    public SwitchParameter NoWait { get; set; }
+
+    private bool _yesToAll;
+    private bool _noToAll;
+
+    protected override void ProcessRecord()
     {
-        [Parameter(
-            Position = 0,
-            ValueFromPipeline = true,
-            Mandatory = true,
-            ValueFromPipelineByPropertyName = true)]
-        public string[] Id { get; set; }
-
-        [Parameter]
-        public SwitchParameter NoWait
+        foreach (var id in Id)
         {
-            get => _nowait;
-            set => _nowait = value;
-        }
-
-        private bool _nowait;
-
-
-        protected override void ProcessRecord()
-        {
-            foreach (var id in Id)
+            Project project;
+            try
             {
-                WaitForProject(Factory.CreateProjectsClient().Delete(id)
-                    , _nowait, false, id);
+                project = Factory.CreateProjectsClient().Get(id);
+            }
+            catch (Exception ex)
+            {
+                WriteError(new ErrorRecord(ex, "ProjectNotFound", ErrorCategory.ObjectNotFound, id));
+                continue;
             }
 
-        }
+            if (!Force && !ShouldContinue($"Project '{project.Name}' (Id:{id}) will be deleted!", "Warning!",
+                    ref _yesToAll, ref _noToAll))
+            {
+                continue;
+            }
 
+            WaitForProject(Factory.CreateProjectsClient().Delete(id), NoWait, false, id);
+        }
     }
 }


### PR DESCRIPTION
This PR adds a confirmation step when deleting projects and introduces the `-Force` parameter to overwrite the confirmation.

Closes #65.