### PR TITLE
Fix output type for virtual disk cmdlet

### DIFF
--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
@@ -6,8 +6,8 @@ namespace Eryph.ComputeClient.Commands.Catlets;
 
 [PublicAPI]
 [Cmdlet(VerbsCommon.Get, "CatletDisk", DefaultParameterSetName = "get")]
-[OutputType(typeof(Catlet), ParameterSetName = ["get"])]
-[OutputType(typeof(Catlet), ParameterSetName = ["list"])]
+[OutputType(typeof(VirtualDisk), ParameterSetName = ["get"])]
+[OutputType(typeof(VirtualDisk), ParameterSetName = ["list"])]
 public class GetCatletDiskCommand : CatletDiskCmdlet
 {
     [Parameter(


### PR DESCRIPTION
This PR fixes the `[OutputType]` specification for `Get-CatletDisk`.