### PR TITLE
Support native YAML for fodder content

### DIFF
--- a/src/Eryph.ComputeClient.Commands/Catlets/CatletConfigCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/CatletConfigCmdlet.cs
@@ -23,17 +23,10 @@ namespace Eryph.ComputeClient.Commands.Catlets
             configString = configString.Replace("\r\n", "\n");
 
             if (configString.StartsWith("{") && configString.EndsWith("}"))
-                return CatletConfigDictionaryConverter.Convert(ConfigModelJsonSerializer.DeserializeToDictionary(configString));
+                return CatletConfigJsonSerializer.Deserialize(configString);
 
-            //YAML
-            try
-            {
-                return CatletConfigYamlSerializer.Deserialize(configString);
-            }
-            catch (YamlException ex)
-            {
-                throw ex;
-            }
+            
+            return CatletConfigYamlSerializer.Deserialize(configString);
 
         }
 

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
@@ -76,8 +76,8 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
         private void WriteConfig(CatletConfiguration config)
         {
-            var catletConfig = CatletConfigDictionaryConverter.Convert(
-                ConfigModelJsonSerializer.DeserializeToDictionary(config.Configuration));
+            var catletConfig = CatletConfigJsonSerializer.Deserialize(
+                config.Configuration);
 
             var yaml = CatletConfigYamlSerializer.Serialize(catletConfig);
             WriteObject(yaml);

--- a/src/Eryph.ComputeClient.Commands/Catlets/NewCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/NewCatletCommand.cs
@@ -2,8 +2,6 @@
 using System.Collections;
 using System.Management.Automation;
 using System.Text;
-using System.Text.Json;
-using System.Text.RegularExpressions;
 using Eryph.ComputeClient.Models;
 using Eryph.ConfigModel.Catlets;
 using Eryph.ConfigModel.Json;
@@ -105,7 +103,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             if (!PopulateVariables(config, Variables, SkipVariablesPrompt))
                 return;
 
-            var serializedConfig = JsonSerializer.SerializeToElement(config, ConfigModelJsonSerializer.DefaultOptions);
+            var serializedConfig = CatletConfigJsonSerializer.SerializeToElement(config);
 
             WaitForOperation(
                 Factory.CreateCatletsClient().Create(

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -23,6 +23,7 @@ namespace Eryph.ComputeClient.Commands
         {
             get
             {
+                // TODO just for testing
                 bool debug;
                 var containsDebug = MyInvocation.BoundParameters.ContainsKey("Debug");
                 if (containsDebug)

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -23,7 +23,6 @@ namespace Eryph.ComputeClient.Commands
         {
             get
             {
-                // TODO just for testing
                 bool debug;
                 var containsDebug = MyInvocation.BoundParameters.ContainsKey("Debug");
                 if (containsDebug)

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.25" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.25" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.25" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.6.2-PullRequest0096.25" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.6.2-PullRequest0096.34" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.7.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,9 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.0" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.6.0" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.6.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.25" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.25" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.25" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.6.2-PullRequest0096.25" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.6.2-PullRequest0096.38" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.7.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.6.2-PullRequest0096.36" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ComputeClient.Commands/Networks/GetVNetworksCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Networks/GetVNetworksCommand.cs
@@ -64,13 +64,11 @@ namespace Eryph.ComputeClient.Commands.Networks
 
         private void WriteConfig(VirtualNetworkConfiguration config)
         {
+            var networkConfig = ProjectNetworksConfigJsonSerializer.Deserialize(
+                config.Configuration);
 
-            var catletConfig = ProjectNetworksConfigDictionaryConverter.Convert(
-                ConfigModelJsonSerializer.DeserializeToDictionary(config.Configuration));
-
-            var yaml = ProjectNetworkConfigYamlSerializer.Serialize(catletConfig);
+            var yaml = ProjectNetworksConfigYamlSerializer.Serialize(networkConfig);
             WriteObject(yaml);
-
         }
 
     }

--- a/src/Eryph.ComputeClient.Commands/Networks/NetworkConfigCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Networks/NetworkConfigCmdlet.cs
@@ -5,32 +5,20 @@ using Eryph.ConfigModel.Networks;
 using Eryph.ConfigModel.Yaml;
 using YamlDotNet.Core;
 
-namespace Eryph.ComputeClient.Commands.Networks
+namespace Eryph.ComputeClient.Commands.Networks;
+
+public class NetworkConfigCmdlet : NetworkCmdLet
 {
-    public class NetworkConfigCmdlet : NetworkCmdLet
+
+    protected static ProjectNetworksConfig DeserializeConfigString(string configString)
     {
+        configString = configString.Trim();
+        configString = configString.Replace("\r\n", "\n");
 
-        protected static ProjectNetworksConfig DeserializeConfigString(string configString)
-        {
-            configString = configString.Trim();
-            configString = configString.Replace("\r\n", "\n");
+        if (configString.StartsWith("{") && configString.EndsWith("}"))
+            return ProjectNetworksConfigJsonSerializer.Deserialize(configString);
 
-            if (configString.StartsWith("{") && configString.EndsWith("}"))
-                return  ProjectNetworksConfigDictionaryConverter.Convert(
-                    ConfigModelJsonSerializer.DeserializeToDictionary(configString));
 
-            
-            //YAML
-            try
-            {
-                return ProjectNetworkConfigYamlSerializer.Deserialize(configString);
-            }
-            catch (YamlException ex)
-            {
-                throw ex;
-            }
-
-        }
-
+        return ProjectNetworksConfigYamlSerializer.Deserialize(configString);
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Networks/SetVNetworkCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Networks/SetVNetworkCommand.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Management.Automation;
 using System.Text;
-using System.Text.Json;
 using Eryph.ComputeClient.Models;
 using Eryph.ConfigModel.Json;
-using Eryph.ConfigModel.Networks;
 using JetBrains.Annotations;
 
 namespace Eryph.ComputeClient.Commands.Networks
@@ -77,7 +75,7 @@ namespace Eryph.ComputeClient.Commands.Networks
             }
                 
             config.Project = ProjectName;
-            var configJson = JsonSerializer.SerializeToElement(config, ConfigModelJsonSerializer.DefaultOptions);
+            var configJson = ProjectNetworksConfigJsonSerializer.SerializeToElement(config);
             
             WaitForOperation(
                 Factory.CreateVirtualNetworksClient().UpdateConfig(


### PR DESCRIPTION
This PR adds support for specifying the fodder content directly as a YAML mapping. Additionally, the JSON serialization for catlet, fodder, and project network configurations now uses snake case.