### PR TITLE
Support termination of VM worker process

### DIFF
--- a/src/Eryph.ComputeClient.Commands/Catlets/CatletStopMode.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/CatletStopMode.cs
@@ -10,4 +10,5 @@ public enum CatletStopMode
 {
     Shutdown = 0,
     Hard = 1,
+    Kill = 2,
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
@@ -31,7 +31,10 @@ namespace Eryph.ComputeClient.Commands.Catlets
         [Parameter]
         public CatletStopMode Mode { get; set; }
 
-        private bool _yesToAll, _noToAll;
+        private bool _yesToAll;
+        private bool _noToAll;
+        private bool _yesToKillAll;
+        private bool _noToKillAll;
 
         protected override void ProcessRecord()
         {
@@ -58,6 +61,17 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
                 if (!Force && !ShouldContinue($"Catlet '{catlet.Name}' (Id:{id}) will be stopped!", "Warning!",
                     ref _yesToAll, ref _noToAll))
+                {
+                    continue;
+                }
+
+                if (Mode == CatletStopMode.Kill
+                    && !Force
+                    && !ShouldContinue(
+                        $"The worker process of catlet '{catlet.Name}' (Id:{id}) will be terminated! "
+                        + "This can cause inconsistent behavior in Hyper-V and should only be done when the VM does not respond to normal commands.",
+                        "Danger!",
+                        true, ref _yesToKillAll, ref _noToKillAll))
                 {
                     continue;
                 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
@@ -39,6 +39,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             {
                 CatletStopMode.Shutdown => Models.CatletStopMode.Shutdown,
                 CatletStopMode.Hard => Models.CatletStopMode.Hard,
+                CatletStopMode.Kill => Models.CatletStopMode.Kill,
                 _ => throw new PSArgumentOutOfRangeException("The stop mode is not supported", Mode, nameof(Mode)),
             };
 

--- a/src/Eryph.ComputeClient/Generated/Models/CatletStopMode.cs
+++ b/src/Eryph.ComputeClient/Generated/Models/CatletStopMode.cs
@@ -24,11 +24,14 @@ namespace Eryph.ComputeClient.Models
 
         private const string ShutdownValue = "Shutdown";
         private const string HardValue = "Hard";
+        private const string KillValue = "Kill";
 
         /// <summary> Shutdown. </summary>
         public static CatletStopMode Shutdown { get; } = new CatletStopMode(ShutdownValue);
         /// <summary> Hard. </summary>
         public static CatletStopMode Hard { get; } = new CatletStopMode(HardValue);
+        /// <summary> Kill. </summary>
+        public static CatletStopMode Kill { get; } = new CatletStopMode(KillValue);
         /// <summary> Determines if two <see cref="CatletStopMode"/> values are the same. </summary>
         public static bool operator ==(CatletStopMode left, CatletStopMode right) => left.Equals(right);
         /// <summary> Determines if two <see cref="CatletStopMode"/> values are not the same. </summary>


### PR DESCRIPTION
This PR adds support for new option in the `Stop-Catlet` cmdlet which terminates the VM worker process of a catlet. This option
can be used when the Hyper-V VM does not respond to normal commands anymore.