### PR TITLE
Compatibility with API 1.1 (eryph 0.4)

### DIFF
--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/CatletSpecificationCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/CatletSpecificationCmdlet.cs
@@ -11,6 +11,12 @@ namespace Eryph.ComputeClient.Commands.CatletSpecifications;
 [PublicAPI]
 public abstract class CatletSpecificationCmdlet : ComputeCmdLet
 {
+    protected override void BeginProcessing()
+    {
+        base.BeginProcessing();
+        RequireApiVersion(1, 2, "catlet specifications");
+    }
+
     protected CatletSpecification GetSingleCatletSpecification(string id)
     {
         return Factory.CreateCatletSpecificationsClient().Get(id);

--- a/src/Eryph.ComputeClient.Commands/Catlets/DeployCatlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/DeployCatlet.cs
@@ -50,6 +50,12 @@ public class DeployCatlet : CatletConfigCmdlet
     [Parameter]
     public SwitchParameter NoWait { get; set; }
 
+    protected override void BeginProcessing()
+    {
+        base.BeginProcessing();
+        RequireApiVersion(1, 2, "catlet specifications");
+    }
+
     protected override void ProcessRecord()
     {
         var specificationId = Version?.SpecificationId ?? SpecificationId;

--- a/src/Eryph.ComputeClient.Commands/Catlets/DeployCatlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/DeployCatlet.cs
@@ -53,7 +53,7 @@ public class DeployCatlet : CatletConfigCmdlet
     protected override void BeginProcessing()
     {
         base.BeginProcessing();
-        RequireApiVersion(1, 2, "catlet specifications");
+        RequireApiVersion(1, 2, "Deploy-Catlet");
     }
 
     protected override void ProcessRecord()

--- a/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
@@ -34,7 +34,10 @@ namespace Eryph.ComputeClient.Commands.Catlets
             {
                 var config = DeserializeConfigString(Config);
 
-                if (config.ConfigType is not CatletConfigType.Instance)
+                // The config_type field was introduced in API 1.2. Older servers neither
+                // emit nor expect it, so we only enforce the instance check against 1.2+.
+                if (GetApiVersion().IsCompatible(1, 2)
+                    && config.ConfigType is not CatletConfigType.Instance)
                 {
                     WriteError(new ErrorRecord(
                         new InvalidOperationException("The catlet configuration is not an instance configuration "

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -99,7 +99,7 @@ namespace Eryph.ComputeClient.Commands
             ThrowTerminatingError(new ErrorRecord(
                 new InvalidOperationException(message),
                 "ApiVersionNotSupported",
-                ErrorCategory.NotInstalled,
+                ErrorCategory.InvalidOperation,
                 null));
         }
 

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -87,6 +87,22 @@ namespace Eryph.ComputeClient.Commands
             return _apiVersionInfo;
         }
 
+        protected void RequireApiVersion(int major, int minor, string feature)
+        {
+            var version = GetApiVersion();
+            if (version.IsCompatible(major, minor))
+                return;
+
+            var message = $"The feature '{feature}' requires eryph API version {major}.{minor} or higher, "
+                          + $"but the server reports version {version.Major}.{version.Minor}. "
+                          + "Please update the eryph server.";
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException(message),
+                "ApiVersionNotSupported",
+                ErrorCategory.NotInstalled,
+                null));
+        }
+
         protected void WriteResources(Operation operation, ResourceType resourceType)
         {
             var resourceData = Factory.CreateOperationsClient()

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.9.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.9.1-ci.3" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.9.1-ci.3" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.9.1-ci.3" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.9.1-ci.3" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.10.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.10.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.10.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Yaml" Version="0.10.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Bump `Eryph.ConfigModel.*` to 0.10.0.
- Gate catlet specifications cmdlets and `Deploy-Catlet` on API >= 1.2 with a friendly `ApiVersionNotSupported` error.
- Only enforce `Update-Catlet` ConfigType=Instance check on API >= 1.2; on 1.1 servers the legacy update flow proceeds.

## Test plan
- [x] Build clean on net462 + net8.0.
- [x] Smoke tested against eryph-zero v0.4 (API 1.1): list/get/get-config/test, create + update + remove catlet.
- [x] Specification cmdlets and `Deploy-Catlet` reject with the new error on 1.1.