### PR TITLE
Rename Deploy-Catlet cmdlet to Submit-CatletDeployment

### DIFF
--- a/build/Eryph.ComputeClient.psd1
+++ b/build/Eryph.ComputeClient.psd1
@@ -77,7 +77,7 @@ CmdletsToExport = @(
     "New-Catlet",
     "Remove-Catlet",
     "Update-Catlet",
-    "Deploy-Catlet",
+    "Submit-CatletDeployment",
     "Start-Catlet",
     "Stop-Catlet",
     "Get-CatletIp",
@@ -108,7 +108,9 @@ CmdletsToExport = @(
 VariablesToExport = '*'
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @()
+AliasesToExport = @(
+    "Deploy-Catlet"
+)
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/src/Eryph.ComputeClient.Commands/Catlets/SubmitCatletDeployment.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/SubmitCatletDeployment.cs
@@ -9,9 +9,10 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Catlets;
 
 [PublicAPI]
-[Cmdlet("Deploy", "Catlet")]
+[Cmdlet("Submit", "CatletDeployment")]
+[Alias("Deploy-Catlet")]
 [OutputType(typeof(Operation))]
-public class DeployCatlet : CatletConfigCmdlet
+public class SubmitCatletDeployment : CatletConfigCmdlet
 {
     [Parameter(
         ParameterSetName = "Parameter",


### PR DESCRIPTION
The verb `Deploy` is only an approved PowerShell verb in PowerShell 6+. In Windows PowerShell 5.1 it triggers an "unapproved verbs" warning when the module is imported.

This renames the cmdlet to use the approved verb `Submit` (`Submit-CatletDeployment`) and keeps `Deploy-Catlet` as an exported alias, so existing scripts keep working and no warning is shown on any PowerShell version.