### PR TITLE
Improve cmdlet OutputType declarations per parameter set

### DIFF
--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/RemoveCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/RemoveCatletSpecification.cs
@@ -6,8 +6,9 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.CatletSpecifications;
 
 [PublicAPI]
-[Cmdlet(VerbsCommon.Remove, "CatletSpecification")]
-[OutputType(typeof(Operation), typeof(CatletSpecification))]
+[Cmdlet(VerbsCommon.Remove, "CatletSpecification", DefaultParameterSetName = "Wait")]
+[OutputType(typeof(CatletSpecification), ParameterSetName = new[] { "Wait" })]
+[OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
 public class RemoveCatletSpecification : CatletSpecificationCmdlet
 {
     [Parameter(
@@ -27,7 +28,7 @@ public class RemoveCatletSpecification : CatletSpecificationCmdlet
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
-    [Parameter]
+    [Parameter(ParameterSetName = "NoWait")]
     public SwitchParameter NoWait { get; set; }
 
     [Parameter]

--- a/src/Eryph.ComputeClient.Commands/Catlets/NewCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/NewCatletDiskCmdlet.cs
@@ -11,8 +11,9 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Catlets;
 
 [PublicAPI]
-[Cmdlet(VerbsCommon.New, "CatletDisk")]
-[OutputType(typeof(Operation), typeof(VirtualDisk))]
+[Cmdlet(VerbsCommon.New, "CatletDisk", DefaultParameterSetName = "Wait")]
+[OutputType(typeof(VirtualDisk), ParameterSetName = new[] { "Wait" })]
+[OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
 public class NewCatletDiskCmdlet : CatletDiskCmdlet
 {
     [Parameter(Mandatory = true)]
@@ -39,7 +40,7 @@ public class NewCatletDiskCmdlet : CatletDiskCmdlet
     [ValidateNotNullOrEmpty]
     public string Environment { get; set; }
 
-    [Parameter]
+    [Parameter(ParameterSetName = "NoWait")]
     public SwitchParameter NoWait { get; set; }
 
     protected override void ProcessRecord()

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletCommand.cs
@@ -7,8 +7,9 @@ using Operation = Eryph.ComputeClient.Models.Operation;
 namespace Eryph.ComputeClient.Commands.Catlets
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.Remove, "Catlet")]
-    [OutputType(typeof(Operation), typeof(Catlet))]
+    [Cmdlet(VerbsCommon.Remove, "Catlet", DefaultParameterSetName = "Wait")]
+    [OutputType(typeof(Catlet), ParameterSetName = new[] { "Wait" })]
+    [OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
     public class RemoveCatletCommand : CatletCmdLet
     {
         [Parameter(
@@ -43,7 +44,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             set => _passThru = value;
         }
 
-        [Parameter]
+        [Parameter(ParameterSetName = "NoWait")]
         public SwitchParameter NoWait
         {
             get => _nowait;

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
@@ -10,8 +10,9 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Catlets;
 
 [PublicAPI]
-[Cmdlet(VerbsCommon.Remove, "CatletDisk")]
-[OutputType(typeof(Operation), typeof(VirtualDisk))]
+[Cmdlet(VerbsCommon.Remove, "CatletDisk", DefaultParameterSetName = "Wait")]
+[OutputType(typeof(VirtualDisk), ParameterSetName = new[] { "Wait" })]
+[OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
 public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
 {
     [Parameter(
@@ -38,7 +39,7 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
-    [Parameter]
+    [Parameter(ParameterSetName = "NoWait")]
     public SwitchParameter NoWait { get; set; }
 
     [Parameter]

--- a/src/Eryph.ComputeClient.Commands/Catlets/StartCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/StartCatletCommand.cs
@@ -8,8 +8,9 @@ using Operation = Eryph.ComputeClient.Models.Operation;
 namespace Eryph.ComputeClient.Commands.Catlets
 {
     [PublicAPI]
-    [Cmdlet(VerbsLifecycle.Start, "Catlet")]
-    [OutputType(typeof(Operation), typeof(Catlet))]
+    [Cmdlet(VerbsLifecycle.Start, "Catlet", DefaultParameterSetName = "Wait")]
+    [OutputType(typeof(Catlet), ParameterSetName = new[] { "Wait" })]
+    [OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
     public class StartCatletCommand : CatletCmdLet
     {
         [Parameter(
@@ -32,7 +33,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             set => _force = value;
         }
 
-        [Parameter]
+        [Parameter(ParameterSetName = "NoWait")]
         public SwitchParameter NoWait
         {
             get => _nowait;

--- a/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
@@ -6,8 +6,9 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Catlets
 {
     [PublicAPI]
-    [Cmdlet(VerbsLifecycle.Stop, "Catlet")]
-    [OutputType(typeof(Operation), typeof(Catlet))]
+    [Cmdlet(VerbsLifecycle.Stop, "Catlet", DefaultParameterSetName = "Wait")]
+    [OutputType(typeof(Catlet), ParameterSetName = new[] { "Wait" })]
+    [OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
     public class StopCatletCommand : CatletCmdLet
     {
         [Parameter(
@@ -26,7 +27,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
         [Parameter]
         public SwitchParameter Force { get; set; }
 
-        [Parameter]
+        [Parameter(ParameterSetName = "NoWait")]
         public SwitchParameter NoWait { get; set; }
 
         [Parameter]

--- a/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
@@ -10,7 +10,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
 {
     [PublicAPI]
     [Cmdlet(VerbsData.Update, "Catlet")]
-    [OutputType(typeof(Operation), typeof(Catlet), typeof(Catlet))]
+    [OutputType(typeof(Operation), typeof(Catlet))]
     public class UpdateCatletCommand : CatletConfigCmdlet
     {
         [Parameter(

--- a/src/Eryph.ComputeClient.Commands/Projects/NewProjectCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Projects/NewProjectCommand.cs
@@ -7,8 +7,9 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Projects
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.New, "EryphProject")]
-    [OutputType(typeof(Operation), typeof(Project))]
+    [Cmdlet(VerbsCommon.New, "EryphProject", DefaultParameterSetName = "Wait")]
+    [OutputType(typeof(Project), ParameterSetName = new[] { "Wait" })]
+    [OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
     public class NewProjectCommand : ProjectCmdlet
     {
         [Parameter(
@@ -18,7 +19,7 @@ namespace Eryph.ComputeClient.Commands.Projects
             ValueFromPipelineByPropertyName = true)]
         public string Name { get; set; }
 
-        [Parameter]
+        [Parameter(ParameterSetName = "NoWait")]
         public SwitchParameter NoWait
         {
             get => _nowait;


### PR DESCRIPTION
Part of #84.

Splits the `-NoWait` switch into `Wait`/`NoWait` parameter sets for the simple single-input action cmdlets (Start/Stop/Remove-Catlet, New/Remove-CatletDisk, New-EryphProject, Remove-CatletSpecification) so each set resolves to a single `[OutputType]`: the resource type by default, `Operation` with `-NoWait`.

Also dedupes the `Update-Catlet` OutputType (`Catlet` was listed twice). Multi-input cmdlets that already use parameter sets (New-Catlet, etc.) are left as cleaned-up multi-type declarations to avoid a combinatorial set explosion.