### PR TITLE
Allow looking up resources by name

### DIFF
--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecification.cs
@@ -31,6 +31,12 @@ public class GetCatletSpecification : CatletSpecificationCmdlet
     [ValidateNotNullOrEmpty]
     public string ProjectName { get; set; }
 
+    [Parameter(
+        ParameterSetName = "list",
+        ValueFromPipelineByPropertyName = true)]
+    [ValidateNotNullOrEmpty]
+    public string Name { get; set; }
+
     protected override void ProcessRecord()
     {
         if (Id is not null)
@@ -44,12 +50,9 @@ public class GetCatletSpecification : CatletSpecificationCmdlet
         }
 
         var projectId = GetProjectId(ProjectName);
-        var specifications = Factory.CreateCatletSpecificationsClient().List(projectId: projectId);
-        foreach (var specification in specifications)
-        {
-            if (Stopping) break;
-
-            WriteObject(specification, true);
-        }
+        WriteFilteredByName(
+            Factory.CreateCatletSpecificationsClient().List(projectId: projectId),
+            Name,
+            specification => specification.Name);
     }
 }

--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecification.cs
@@ -49,7 +49,9 @@ public class GetCatletSpecification : CatletSpecificationCmdlet
             return;
         }
 
-        var projectId = GetProjectId(ProjectName);
+        if (!TryGetProjectId(ProjectName, out var projectId))
+            return;
+
         WriteByNameOrId(
             Name,
             GetSingleCatletSpecification,

--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecification.cs
@@ -12,28 +12,26 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.CatletSpecifications;
 
 [PublicAPI]
-[Cmdlet(VerbsCommon.Get, "CatletSpecification", DefaultParameterSetName = "get")]
+[Cmdlet(VerbsCommon.Get, "CatletSpecification", DefaultParameterSetName = "list")]
 [OutputType(typeof(CatletSpecification), ParameterSetName = ["get"])]
 [OutputType(typeof(CatletSpecification), ParameterSetName = ["list"])]
 public class GetCatletSpecification : CatletSpecificationCmdlet
 {
     [Parameter(
         ParameterSetName = "get",
-        Position = 0,
         ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true)]
     public string[] Id { get; set; }
 
     [Parameter(
         ParameterSetName = "list",
-        ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true)]
     [ValidateNotNullOrEmpty]
     public string ProjectName { get; set; }
 
     [Parameter(
         ParameterSetName = "list",
-        ValueFromPipelineByPropertyName = true)]
+        Position = 0)]
     [ValidateNotNullOrEmpty]
     public string Name { get; set; }
 
@@ -43,16 +41,20 @@ public class GetCatletSpecification : CatletSpecificationCmdlet
         {
             foreach (var id in Id)
             {
-                WriteObject(GetSingleCatletSpecification(id));
+                if (Stopping) break;
+                if (TryGetById(id, GetSingleCatletSpecification, "catlet specification", out var specification))
+                    WriteObject(specification);
             }
 
             return;
         }
 
         var projectId = GetProjectId(ProjectName);
-        WriteFilteredByName(
-            Factory.CreateCatletSpecificationsClient().List(projectId: projectId),
+        WriteByNameOrId(
             Name,
-            specification => specification.Name);
+            GetSingleCatletSpecification,
+            () => Factory.CreateCatletSpecificationsClient().List(projectId: projectId),
+            specification => specification.Name,
+            "catlet specification");
     }
 }

--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/RemoveCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/RemoveCatletSpecification.cs
@@ -15,6 +15,7 @@ public class RemoveCatletSpecification : CatletSpecificationCmdlet
         ValueFromPipeline = true,
         Mandatory = true,
         ValueFromPipelineByPropertyName = true)]
+    [Alias("Name")]
     public string[] Id { get; set; }
 
     [Parameter]
@@ -34,37 +35,33 @@ public class RemoveCatletSpecification : CatletSpecificationCmdlet
 
     protected override void ProcessRecord()
     {
-        foreach (var id in Id)
+        foreach (var nameOrId in Id)
         {
-            CatletSpecification specification;
-            try
+            foreach (var specification in ResolveByNameOrId(nameOrId, GetSingleCatletSpecification,
+                         () => Factory.CreateCatletSpecificationsClient().List(),
+                         s => s.Name, "catlet specification"))
             {
-                specification = Factory.CreateCatletSpecificationsClient().Get(id);
-            }
-            catch (Exception ex)
-            {
-                WriteError(new ErrorRecord(ex, "CatletSpecificationNotFound", ErrorCategory.ObjectNotFound, id));
-                continue;
-            }
+                if (Stopping) break;
 
-            if (!Force && !ShouldContinue($"Catlet specification '{specification.Name}' (Id:{id}) will be deleted!", "Warning!",
-                    ref _yesToAll, ref _noToAll))
-            {
-                continue;
+                if (!Force && !ShouldContinue($"Catlet specification '{specification.Name}' (Id:{specification.Id}) will be deleted!", "Warning!",
+                        ref _yesToAll, ref _noToAll))
+                {
+                    continue;
+                }
+
+                WaitForOperation(Factory.CreateCatletSpecificationsClient().Delete(
+                        specification.Id,
+                        new DeleteCatletSpecificationRequestBody
+                        {
+                            DeleteCatlet = RemoveCatlet,
+                        }),
+                    NoWait,
+                    false,
+                    specification.Id);
+
+                if (PassThru)
+                    WriteObject(specification);
             }
-
-            WaitForOperation(Factory.CreateCatletSpecificationsClient().Delete(
-                    id,
-                    new DeleteCatletSpecificationRequestBody
-                    {
-                        DeleteCatlet = RemoveCatlet,
-                    }),
-                NoWait,
-                false,
-                id);
-
-            if (PassThru)
-                WriteObject(specification);
         }
     }
 }

--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/RemoveCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/RemoveCatletSpecification.cs
@@ -30,6 +30,10 @@ public class RemoveCatletSpecification : CatletSpecificationCmdlet
     [Parameter]
     public SwitchParameter NoWait { get; set; }
 
+    [Parameter]
+    [ValidateNotNullOrEmpty]
+    public string ProjectName { get; set; }
+
     private bool _yesToAll;
     private bool _noToAll;
 
@@ -37,8 +41,8 @@ public class RemoveCatletSpecification : CatletSpecificationCmdlet
     {
         foreach (var nameOrId in Id)
         {
-            foreach (var specification in ResolveByNameOrId(nameOrId, GetSingleCatletSpecification,
-                         () => Factory.CreateCatletSpecificationsClient().List(),
+            foreach (var specification in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatletSpecification,
+                         projectId => Factory.CreateCatletSpecificationsClient().List(projectId: projectId),
                          s => s.Name, "catlet specification"))
             {
                 if (Stopping) break;

--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/UpdateCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/UpdateCatletSpecification.cs
@@ -43,6 +43,10 @@ public class UpdateCatletSpecification : CatletSpecificationCmdlet
     [Parameter]
     public SwitchParameter NoWait { get; set; }
 
+    [Parameter]
+    [ValidateNotNullOrEmpty]
+    public string ProjectName { get; set; }
+
     private readonly StringBuilder _input = new StringBuilder();
 
     protected override void ProcessRecord()
@@ -70,8 +74,8 @@ public class UpdateCatletSpecification : CatletSpecificationCmdlet
             Json.ToBool() ? "application/json" : "application/yaml",
             input);
 
-        foreach (var specification in ResolveByNameOrId(Id, GetSingleCatletSpecification,
-                     () => Factory.CreateCatletSpecificationsClient().List(),
+        foreach (var specification in ResolveActionTargets(Id, ProjectName, GetSingleCatletSpecification,
+                     projectId => Factory.CreateCatletSpecificationsClient().List(projectId: projectId),
                      s => s.Name, "catlet specification"))
         {
             if (Stopping) break;

--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/UpdateCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/UpdateCatletSpecification.cs
@@ -25,6 +25,8 @@ public class UpdateCatletSpecification : CatletSpecificationCmdlet
     [ValidateNotNullOrEmpty]
     public string Config { get; set; }
 
+    // Not positional (unlike the other action cmdlets' -Id): position 0 is taken by
+    // -InputObject, the specification content. The target is given via -Id / -Name.
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     [Alias("Name")]

--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/UpdateCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/UpdateCatletSpecification.cs
@@ -27,6 +27,7 @@ public class UpdateCatletSpecification : CatletSpecificationCmdlet
 
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
+    [Alias("Name")]
     public string Id { get; set; }
 
     [Parameter]
@@ -69,15 +70,22 @@ public class UpdateCatletSpecification : CatletSpecificationCmdlet
             Json.ToBool() ? "application/json" : "application/yaml",
             input);
 
-        WaitForOperation(Factory.CreateCatletSpecificationsClient().Update(
-                Id,
-                new UpdateCatletSpecificationRequestBody(config)
-                {
-                    CorrelationId = Guid.NewGuid(),
-                    Comment = Comment,
-                    Architectures = Architectures,
-                }),
-            NoWait,
-            true);
+        foreach (var specification in ResolveByNameOrId(Id, GetSingleCatletSpecification,
+                     () => Factory.CreateCatletSpecificationsClient().List(),
+                     s => s.Name, "catlet specification"))
+        {
+            if (Stopping) break;
+
+            WaitForOperation(Factory.CreateCatletSpecificationsClient().Update(
+                    specification.Id,
+                    new UpdateCatletSpecificationRequestBody(config)
+                    {
+                        CorrelationId = Guid.NewGuid(),
+                        Comment = Comment,
+                        Architectures = Architectures,
+                    }),
+                NoWait,
+                true);
+        }
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
@@ -17,9 +17,11 @@ namespace Eryph.ComputeClient.Commands.Catlets
     {
         [Parameter(
             ParameterSetName = "get",
-            Position = 0,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
+        // Positional only in the 'getconfig' set, so 'Get-Catlet <id> -Config' works.
+        // The bare positional slot otherwise belongs to -Name in the (default) 'list' set,
+        // consistent with the other Get-* cmdlets.
         [Parameter(
             ParameterSetName = "getconfig",
             Position = 0,
@@ -68,7 +70,8 @@ namespace Eryph.ComputeClient.Commands.Catlets
                 return;
             }
 
-            var projectId = GetProjectId(ProjectName);
+            if (!TryGetProjectId(ProjectName, out var projectId))
+                return;
 
             // 'Get-Catlet -Config' (without -Id) dumps the config of every catlet in
             // scope. -Config lives in the 'getconfig' set, so -Name is never set here.

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
@@ -39,6 +39,12 @@ namespace Eryph.ComputeClient.Commands.Catlets
         [ValidateNotNullOrEmpty]
         public string ProjectName { get; set; }
 
+        [Parameter(
+            ParameterSetName = "list",
+            ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty]
+        public string Name { get; set; }
+
         protected override void ProcessRecord()
         {
 
@@ -56,22 +62,10 @@ namespace Eryph.ComputeClient.Commands.Catlets
             }
 
             var projectId = GetProjectId(ProjectName);
-            foreach (var virtualCatlet in Factory.CreateCatletsClient().List(projectId: projectId))
-            {
-                if (Stopping) break;
-
-                if (Config.IsPresent)
-                {
-                    WriteConfig(Factory.CreateCatletsClient().GetConfig(virtualCatlet.Id));
-
-                }
-                else
-                {
-                    WriteObject(virtualCatlet, true);
-                }
-            }
-
-
+            WriteFilteredByName(
+                Factory.CreateCatletsClient().List(projectId: projectId),
+                Name,
+                catlet => catlet.Name);
         }
 
         private void WriteConfig(CatletConfiguration config)

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
@@ -9,7 +9,7 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Catlets
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.Get, "Catlet", DefaultParameterSetName = "get")]
+    [Cmdlet(VerbsCommon.Get, "Catlet", DefaultParameterSetName = "list")]
     [OutputType(typeof(Catlet), ParameterSetName = new[] { "get" })]
     [OutputType(typeof(Catlet), ParameterSetName = new[] { "list" })]
     [OutputType(typeof(string), ParameterSetName = new[] { "getconfig" })]
@@ -34,14 +34,13 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
         [Parameter(
             ParameterSetName = "list",
-            ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string ProjectName { get; set; }
 
         [Parameter(
             ParameterSetName = "list",
-            ValueFromPipelineByPropertyName = true)]
+            Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Name { get; set; }
 
@@ -52,20 +51,30 @@ namespace Eryph.ComputeClient.Commands.Catlets
             {
                 foreach (var id in Id)
                 {
+                    if (Stopping) break;
+
                     if (Config.IsPresent)
-                        WriteConfig(Factory.CreateCatletsClient().GetConfig(id));
+                    {
+                        if (TryGetById(id, i => Factory.CreateCatletsClient().GetConfig(i), "catlet", out var config))
+                            WriteConfig(config);
+                    }
                     else
-                        WriteObject(GetSingleCatlet(id));
+                    {
+                        if (TryGetById(id, GetSingleCatlet, "catlet", out var catlet))
+                            WriteObject(catlet);
+                    }
                 }
 
                 return;
             }
 
             var projectId = GetProjectId(ProjectName);
-            WriteFilteredByName(
-                Factory.CreateCatletsClient().List(projectId: projectId),
+            WriteByNameOrId(
                 Name,
-                catlet => catlet.Name);
+                GetSingleCatlet,
+                () => Factory.CreateCatletsClient().List(projectId: projectId),
+                catlet => catlet.Name,
+                "catlet");
         }
 
         private void WriteConfig(CatletConfiguration config)

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
@@ -74,10 +74,11 @@ namespace Eryph.ComputeClient.Commands.Catlets
             // scope. -Config lives in the 'getconfig' set, so -Name is never set here.
             if (Config.IsPresent)
             {
-                foreach (var catlet in Factory.CreateCatletsClient().List(projectId: projectId))
+                var catletsClient = Factory.CreateCatletsClient();
+                foreach (var catlet in catletsClient.List(projectId: projectId))
                 {
                     if (Stopping) break;
-                    WriteConfig(Factory.CreateCatletsClient().GetConfig(catlet.Id));
+                    WriteConfig(catletsClient.GetConfig(catlet.Id));
                 }
 
                 return;

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletCommand.cs
@@ -69,6 +69,20 @@ namespace Eryph.ComputeClient.Commands.Catlets
             }
 
             var projectId = GetProjectId(ProjectName);
+
+            // 'Get-Catlet -Config' (without -Id) dumps the config of every catlet in
+            // scope. -Config lives in the 'getconfig' set, so -Name is never set here.
+            if (Config.IsPresent)
+            {
+                foreach (var catlet in Factory.CreateCatletsClient().List(projectId: projectId))
+                {
+                    if (Stopping) break;
+                    WriteConfig(Factory.CreateCatletsClient().GetConfig(catlet.Id));
+                }
+
+                return;
+            }
+
             WriteByNameOrId(
                 Name,
                 GetSingleCatlet,

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
@@ -1,28 +1,39 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
 using Eryph.ComputeClient.Models;
 using JetBrains.Annotations;
 
 namespace Eryph.ComputeClient.Commands.Catlets;
 
 [PublicAPI]
-[Cmdlet(VerbsCommon.Get, "CatletDisk", DefaultParameterSetName = "get")]
+[Cmdlet(VerbsCommon.Get, "CatletDisk", DefaultParameterSetName = "list")]
 [OutputType(typeof(VirtualDisk), ParameterSetName = ["get"])]
 [OutputType(typeof(VirtualDisk), ParameterSetName = ["list"])]
 public class GetCatletDiskCommand : CatletDiskCmdlet
 {
     [Parameter(
         ParameterSetName = "get",
-        Position = 0,
         ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true)]
     public string[] Id { get; set; }
 
     [Parameter(
         ParameterSetName = "list",
-        ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true)]
     [ValidateNotNullOrEmpty]
     public string ProjectName { get; set; }
+
+    [Parameter(
+        ParameterSetName = "list",
+        Position = 0)]
+    [ValidateNotNullOrEmpty]
+    public string Name { get; set; }
+
+    [Parameter(ParameterSetName = "list")]
+    [ValidateNotNullOrEmpty]
+    public string Environment { get; set; }
 
     protected override void ProcessRecord()
     {
@@ -30,13 +41,23 @@ public class GetCatletDiskCommand : CatletDiskCmdlet
         {
             foreach (var id in Id)
             {
-                WriteObject(GetSingleCatletDisk(id));
+                if (Stopping) break;
+                if (TryGetById(id, GetSingleCatletDisk, "catlet disk", out var disk))
+                    WriteObject(disk);
             }
 
             return;
         }
 
         var projectId = GetProjectId(ProjectName);
-        ListOutput(Factory.CreateVirtualDisksClient().List(projectId: projectId));
+
+        // Disk names are unique per project + environment, so allow narrowing by
+        // environment. The environment filter is applied to the listing; an explicit
+        // id (GUID) ignores it.
+        IEnumerable<VirtualDisk> disks = Factory.CreateVirtualDisksClient().List(projectId: projectId);
+        if (!string.IsNullOrWhiteSpace(Environment))
+            disks = disks.Where(d => string.Equals(d.Environment, Environment, StringComparison.OrdinalIgnoreCase));
+
+        WriteByNameOrId(Name, GetSingleCatletDisk, () => disks, d => d.Name, "catlet disk");
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
@@ -49,7 +49,8 @@ public class GetCatletDiskCommand : CatletDiskCmdlet
             return;
         }
 
-        var projectId = GetProjectId(ProjectName);
+        if (!TryGetProjectId(ProjectName, out var projectId))
+            return;
 
         // Disk names are unique per project + environment, so allow narrowing by
         // environment. The environment filter is applied to the listing; an explicit

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletIpCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletIpCommand.cs
@@ -49,7 +49,9 @@ public class GetCatletIpCommand : CatletCmdLet
             return;
         }
 
-        var projectId = GetProjectId(ProjectName);
+        if (!TryGetProjectId(ProjectName, out var projectId))
+            return;
+
         WriteByNameOrId(
             Name,
             GetSingleCatlet,

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletIpCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletIpCommand.cs
@@ -23,6 +23,10 @@ public class GetCatletIpCommand : CatletCmdLet
     [ValidateNotNullOrEmpty]
     public string Name { get; set; }
 
+    [Parameter(ParameterSetName = "list")]
+    [ValidateNotNullOrEmpty]
+    public string ProjectName { get; set; }
+
     [Parameter]
     public SwitchParameter InternalIp { get; set; }
 
@@ -43,10 +47,11 @@ public class GetCatletIpCommand : CatletCmdLet
             return;
         }
 
+        var projectId = GetProjectId(ProjectName);
         WriteByNameOrId(
             Name,
             GetSingleCatlet,
-            () => Factory.CreateCatletsClient().List(),
+            () => Factory.CreateCatletsClient().List(projectId: projectId),
             catlet => catlet.Name,
             "catlet",
             WriteIp);

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletIpCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletIpCommand.cs
@@ -23,7 +23,9 @@ public class GetCatletIpCommand : CatletCmdLet
     [ValidateNotNullOrEmpty]
     public string Name { get; set; }
 
-    [Parameter(ParameterSetName = "list")]
+    [Parameter(
+        ParameterSetName = "list",
+        ValueFromPipelineByPropertyName = true)]
     [ValidateNotNullOrEmpty]
     public string ProjectName { get; set; }
 

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletIpCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletIpCommand.cs
@@ -7,26 +7,26 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Catlets;
 
 [PublicAPI]
-[Cmdlet(VerbsCommon.Get, "CatletIp", DefaultParameterSetName = "get")]
-[OutputType(typeof(NetworkPortIp), ParameterSetName = ["get"])]
+[Cmdlet(VerbsCommon.Get, "CatletIp", DefaultParameterSetName = "list")]
+[OutputType(typeof(NetworkPortIp))]
 public class GetCatletIpCommand : CatletCmdLet
 {
     [Parameter(
         ParameterSetName = "get",
-        Position = 0,
         ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true)]
-
     public string[] Id { get; set; }
 
     [Parameter(
-        ParameterSetName = "get",
-        Mandatory = false)]
+        ParameterSetName = "list",
+        Position = 0)]
+    [ValidateNotNullOrEmpty]
+    public string Name { get; set; }
+
+    [Parameter]
     public SwitchParameter InternalIp { get; set; }
 
-    [Parameter(
-        ParameterSetName = "get",
-        Mandatory = false)]
+    [Parameter]
     public string Network { get; set; }
 
     protected override void ProcessRecord()
@@ -35,20 +35,21 @@ public class GetCatletIpCommand : CatletCmdLet
         {
             foreach (var id in Id)
             {
-                var catlet = GetSingleCatlet(id);
-
-                WriteIp(catlet);
+                if (Stopping) break;
+                if (TryGetById(id, GetSingleCatlet, "catlet", out var catlet))
+                    WriteIp(catlet);
             }
 
             return;
         }
 
-        foreach (var catlet in Factory.CreateCatletsClient().List())
-        {
-            if (Stopping) break;
-
-            WriteIp(catlet);
-        }
+        WriteByNameOrId(
+            Name,
+            GetSingleCatlet,
+            () => Factory.CreateCatletsClient().List(),
+            catlet => catlet.Name,
+            "catlet",
+            WriteIp);
     }
 
     private void WriteIp(Catlet catlet)

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletCommand.cs
@@ -16,6 +16,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             ValueFromPipeline = true,
             Mandatory = true,
             ValueFromPipelineByPropertyName = true)]
+        [Alias("Name")]
         public string[] Id { get; set; }
 
         /// <summary>
@@ -59,29 +60,24 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
         protected override void ProcessRecord()
         {
-            foreach (var id in Id)
+            foreach (var nameOrId in Id)
             {
-                Catlet catlet;
-                try
+                foreach (var catlet in ResolveByNameOrId(nameOrId, GetSingleCatlet,
+                             () => Factory.CreateCatletsClient().List(), c => c.Name, "catlet"))
                 {
-                    catlet = Factory.CreateCatletsClient().Get(id);
-                }
-                catch (Exception ex)
-                {
-                    WriteError(new ErrorRecord(ex, "CatletNotFound", ErrorCategory.ObjectNotFound, id));
-                    continue;
-                }
+                    if (Stopping) break;
 
-                if (!Force && !ShouldContinue($"Catlet '{catlet.Name}' (Id:{id}) will be deleted!", "Warning!",
-                    ref _yesToAll, ref _noToAll))
-                {
-                    continue;
+                    if (!Force && !ShouldContinue($"Catlet '{catlet.Name}' (Id:{catlet.Id}) will be deleted!", "Warning!",
+                        ref _yesToAll, ref _noToAll))
+                    {
+                        continue;
+                    }
+
+                    WaitForOperation(Factory.CreateCatletsClient().Delete(catlet.Id).Value, _nowait, false, catlet.Id);
+
+                    if (PassThru)
+                        WriteObject(catlet);
                 }
-
-                WaitForOperation(Factory.CreateCatletsClient().Delete(id).Value, _nowait, false, id);
-
-                if (PassThru)
-                    WriteObject(catlet);
             }
 
         }

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletCommand.cs
@@ -50,6 +50,10 @@ namespace Eryph.ComputeClient.Commands.Catlets
             set => _nowait = value;
         }
 
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string ProjectName { get; set; }
+
         private bool _force;
         private bool _nowait;
         private bool _passThru;
@@ -62,8 +66,8 @@ namespace Eryph.ComputeClient.Commands.Catlets
         {
             foreach (var nameOrId in Id)
             {
-                foreach (var catlet in ResolveByNameOrId(nameOrId, GetSingleCatlet,
-                             () => Factory.CreateCatletsClient().List(), c => c.Name, "catlet"))
+                foreach (var catlet in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatlet,
+                             projectId => Factory.CreateCatletsClient().List(projectId: projectId), c => c.Name, "catlet"))
                 {
                     if (Stopping) break;
 

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
@@ -41,6 +41,10 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
     [Parameter]
     public SwitchParameter NoWait { get; set; }
 
+    [Parameter]
+    [ValidateNotNullOrEmpty]
+    public string ProjectName { get; set; }
+
     private bool _yesToAll;
     private bool _noToAll;
 
@@ -48,8 +52,8 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
     {
         foreach (var nameOrId in Id)
         {
-            foreach (var virtualDisk in ResolveByNameOrId(nameOrId, GetSingleCatletDisk,
-                         () => Factory.CreateVirtualDisksClient().List(),
+            foreach (var virtualDisk in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatletDisk,
+                         projectId => Factory.CreateVirtualDisksClient().List(projectId: projectId),
                          d => d.Name, "catlet disk"))
             {
                 if (Stopping) break;

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
@@ -60,7 +60,7 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
                          projectId => Factory.CreateVirtualDisksClient().List(projectId: projectId)
                              .Where(d => string.IsNullOrWhiteSpace(Environment)
                                          || string.Equals(d.Environment, Environment, StringComparison.OrdinalIgnoreCase)),
-                         d => d.Name, "catlet disk"))
+                         d => d.Name, "catlet disk", ambiguityHint: "-Environment"))
             {
                 if (Stopping) break;
 

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
@@ -48,8 +48,7 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
     {
         foreach (var nameOrId in Id)
         {
-            foreach (var virtualDisk in ResolveByNameOrId(nameOrId,
-                         id => Factory.CreateVirtualDisksClient().Get(id).Value,
+            foreach (var virtualDisk in ResolveByNameOrId(nameOrId, GetSingleCatletDisk,
                          () => Factory.CreateVirtualDisksClient().List(),
                          d => d.Name, "catlet disk"))
             {

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
@@ -45,6 +45,10 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
     [ValidateNotNullOrEmpty]
     public string ProjectName { get; set; }
 
+    [Parameter]
+    [ValidateNotNullOrEmpty]
+    public string Environment { get; set; }
+
     private bool _yesToAll;
     private bool _noToAll;
 
@@ -53,7 +57,9 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
         foreach (var nameOrId in Id)
         {
             foreach (var virtualDisk in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatletDisk,
-                         projectId => Factory.CreateVirtualDisksClient().List(projectId: projectId),
+                         projectId => Factory.CreateVirtualDisksClient().List(projectId: projectId)
+                             .Where(d => string.IsNullOrWhiteSpace(Environment)
+                                         || string.Equals(d.Environment, Environment, StringComparison.OrdinalIgnoreCase)),
                          d => d.Name, "catlet disk"))
             {
                 if (Stopping) break;

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
@@ -19,6 +19,7 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
         ValueFromPipeline = true,
         Mandatory = true,
         ValueFromPipelineByPropertyName = true)]
+    [Alias("Name")]
     public string[] Id { get; set; }
 
     /// <summary>
@@ -45,29 +46,26 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
 
     protected override void ProcessRecord()
     {
-        foreach (var id in Id)
+        foreach (var nameOrId in Id)
         {
-            VirtualDisk virtualDisk;
-            try
+            foreach (var virtualDisk in ResolveByNameOrId(nameOrId,
+                         id => Factory.CreateVirtualDisksClient().Get(id).Value,
+                         () => Factory.CreateVirtualDisksClient().List(),
+                         d => d.Name, "catlet disk"))
             {
-                virtualDisk = Factory.CreateVirtualDisksClient().Get(id);
-            }
-            catch (Exception ex)
-            {
-                WriteError(new ErrorRecord(ex, "CatletDiskNotFound", ErrorCategory.ObjectNotFound, id));
-                continue;
-            }
+                if (Stopping) break;
 
-            if (!Force && !ShouldContinue($"Catlet disk '{virtualDisk.Name}' (Id:{id}) will be deleted!", "Warning!",
-                    ref _yesToAll, ref _noToAll))
-            {
-                continue;
+                if (!Force && !ShouldContinue($"Catlet disk '{virtualDisk.Name}' (Id:{virtualDisk.Id}) will be deleted!", "Warning!",
+                        ref _yesToAll, ref _noToAll))
+                {
+                    continue;
+                }
+
+                WaitForOperation(Factory.CreateVirtualDisksClient().Delete(virtualDisk.Id).Value, NoWait, false, virtualDisk.Id);
+
+                if (PassThru)
+                    WriteObject(virtualDisk);
             }
-
-            WaitForOperation(Factory.CreateVirtualDisksClient().Delete(id).Value, NoWait, false, id);
-
-            if (PassThru)
-                WriteObject(virtualDisk);
         }
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/StartCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/StartCatletCommand.cs
@@ -17,6 +17,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             ValueFromPipeline = true,
             Mandatory = true,
             ValueFromPipelineByPropertyName = true)]
+        [Alias("Name")]
         public string[] Id { get; set; }
 
         /// <summary>
@@ -45,29 +46,22 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
         protected override void ProcessRecord()
         {
-            foreach (var id in Id)
+            foreach (var nameOrId in Id)
             {
-                Catlet catlet;
-                try
+                foreach (var catlet in ResolveByNameOrId(nameOrId, GetSingleCatlet,
+                             () => Factory.CreateCatletsClient().List(), c => c.Name, "catlet"))
                 {
-                    catlet = Factory.CreateCatletsClient().Get(id);
-                }
-                catch (Exception ex)
-                {
-                    WriteError(new ErrorRecord(ex, "CatletNotFound", ErrorCategory.ObjectNotFound, id));
-                    continue;
-                }
+                    if (Stopping) break;
 
-                if (!Force && !ShouldContinue($"Catlet '{catlet.Name}' (Id:{id}) will be started!", "Warning!",
-                    ref _yesToAll, ref _noToAll))
-                {
-                    continue;
+                    if (!Force && !ShouldContinue($"Catlet '{catlet.Name}' (Id:{catlet.Id}) will be started!", "Warning!",
+                        ref _yesToAll, ref _noToAll))
+                    {
+                        continue;
+                    }
+
+                    WaitForOperation(Factory.CreateCatletsClient().Start(catlet.Id), _nowait, false, catlet.Id);
                 }
-
-                WaitForOperation(Factory.CreateCatletsClient().Start(id), _nowait, false, id);
-
             }
-
         }
 
     }

--- a/src/Eryph.ComputeClient.Commands/Catlets/StartCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/StartCatletCommand.cs
@@ -39,6 +39,10 @@ namespace Eryph.ComputeClient.Commands.Catlets
             set => _nowait = value;
         }
 
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string ProjectName { get; set; }
+
         private bool _force;
         private bool _nowait;
         private bool _yesToAll, _noToAll;
@@ -48,8 +52,8 @@ namespace Eryph.ComputeClient.Commands.Catlets
         {
             foreach (var nameOrId in Id)
             {
-                foreach (var catlet in ResolveByNameOrId(nameOrId, GetSingleCatlet,
-                             () => Factory.CreateCatletsClient().List(), c => c.Name, "catlet"))
+                foreach (var catlet in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatlet,
+                             projectId => Factory.CreateCatletsClient().List(projectId: projectId), c => c.Name, "catlet"))
                 {
                     if (Stopping) break;
 

--- a/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
@@ -32,6 +32,10 @@ namespace Eryph.ComputeClient.Commands.Catlets
         [Parameter]
         public CatletStopMode Mode { get; set; }
 
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string ProjectName { get; set; }
+
         private bool _yesToAll;
         private bool _noToAll;
         private bool _yesToKillAll;
@@ -49,8 +53,8 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
             foreach (var nameOrId in Id)
             {
-                foreach (var catlet in ResolveByNameOrId(nameOrId, GetSingleCatlet,
-                             () => Factory.CreateCatletsClient().List(), c => c.Name, "catlet"))
+                foreach (var catlet in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatlet,
+                             projectId => Factory.CreateCatletsClient().List(projectId: projectId), c => c.Name, "catlet"))
                 {
                     if (Stopping) break;
 

--- a/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/StopCatletCommand.cs
@@ -15,6 +15,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             ValueFromPipeline = true,
             Mandatory = true,
             ValueFromPipelineByPropertyName = true)]
+        [Alias("Name")]
         public string[] Id { get; set; }
 
         /// <summary>
@@ -46,39 +47,34 @@ namespace Eryph.ComputeClient.Commands.Catlets
                 _ => throw new PSArgumentOutOfRangeException("The stop mode is not supported", Mode, nameof(Mode)),
             };
 
-            foreach (var id in Id)
+            foreach (var nameOrId in Id)
             {
-                Catlet catlet;
-                try
+                foreach (var catlet in ResolveByNameOrId(nameOrId, GetSingleCatlet,
+                             () => Factory.CreateCatletsClient().List(), c => c.Name, "catlet"))
                 {
-                    catlet = Factory.CreateCatletsClient().Get(id);
-                }
-                catch (Exception ex)
-                {
-                    WriteError(new ErrorRecord(ex, "CatletNotFound", ErrorCategory.ObjectNotFound, id));
-                    continue;
-                }
+                    if (Stopping) break;
 
-                if (!Force && !ShouldContinue($"Catlet '{catlet.Name}' (Id:{id}) will be stopped!", "Warning!",
-                    ref _yesToAll, ref _noToAll))
-                {
-                    continue;
-                }
+                    if (!Force && !ShouldContinue($"Catlet '{catlet.Name}' (Id:{catlet.Id}) will be stopped!", "Warning!",
+                        ref _yesToAll, ref _noToAll))
+                    {
+                        continue;
+                    }
 
-                if (Mode == CatletStopMode.Kill
-                    && !Force
-                    && !ShouldContinue(
-                        $"The worker process of catlet '{catlet.Name}' (Id:{id}) will be terminated! "
-                        + "This can cause inconsistent behavior in Hyper-V and should only be done when the VM does not respond to normal commands.",
-                        "Danger!",
-                        true, ref _yesToKillAll, ref _noToKillAll))
-                {
-                    continue;
-                }
+                    if (Mode == CatletStopMode.Kill
+                        && !Force
+                        && !ShouldContinue(
+                            $"The worker process of catlet '{catlet.Name}' (Id:{catlet.Id}) will be terminated! "
+                            + "This can cause inconsistent behavior in Hyper-V and should only be done when the VM does not respond to normal commands.",
+                            "Danger!",
+                            true, ref _yesToKillAll, ref _noToKillAll))
+                    {
+                        continue;
+                    }
 
-                WaitForOperation(
-                    Factory.CreateCatletsClient().Stop(id, new StopCatletRequestBody(stopMode)).Value,
-                    NoWait, false, id);
+                    WaitForOperation(
+                        Factory.CreateCatletsClient().Stop(catlet.Id, new StopCatletRequestBody(stopMode)).Value,
+                        NoWait, false, catlet.Id);
+                }
             }
         }
     }

--- a/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
@@ -18,6 +18,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
             ValueFromPipeline = true,
             Mandatory = true,
             ValueFromPipelineByPropertyName = true)]
+        [Alias("Name")]
         public string[] Id { get; set; }
 
         [Parameter]
@@ -30,39 +31,45 @@ namespace Eryph.ComputeClient.Commands.Catlets
         {
             var client = Factory.CreateCatletsClient();
 
-            foreach (var id in Id)
+            foreach (var nameOrId in Id)
             {
-                var config = DeserializeConfigString(Config);
-
-                // The config_type field was introduced in API 1.2. Older servers neither
-                // emit nor expect it, so we only enforce the instance check against 1.2+.
-                if (GetApiVersion().IsCompatible(1, 2)
-                    && config.ConfigType is not CatletConfigType.Instance)
+                foreach (var catlet in ResolveByNameOrId(nameOrId, GetSingleCatlet,
+                             () => client.List(), c => c.Name, "catlet"))
                 {
-                    WriteError(new ErrorRecord(
-                        new InvalidOperationException("The catlet configuration is not an instance configuration "
-                                                      + "and cannot be used to update an existing catlet. Please "
-                                                      + "use Get-Catlet -Config to get a configuration for update purposes."),
-                        "ConfigIsNotInstanceSpecific",
-                        ErrorCategory.InvalidOperation,
-                        id));
+                    if (Stopping) break;
+
+                    var config = DeserializeConfigString(Config);
+
+                    // The config_type field was introduced in API 1.2. Older servers neither
+                    // emit nor expect it, so we only enforce the instance check against 1.2+.
+                    if (GetApiVersion().IsCompatible(1, 2)
+                        && config.ConfigType is not CatletConfigType.Instance)
+                    {
+                        WriteError(new ErrorRecord(
+                            new InvalidOperationException("The catlet configuration is not an instance configuration "
+                                                          + "and cannot be used to update an existing catlet. Please "
+                                                          + "use Get-Catlet -Config to get a configuration for update purposes."),
+                            "ConfigIsNotInstanceSpecific",
+                            ErrorCategory.InvalidOperation,
+                            catlet.Id));
+                    }
+
+                    if (config.Fodder is not null || config.Variables is not null)
+                        WriteWarning("The fodder and variables cannot be changed when updating a catlet. The provided data will be ignored.");
+
+                    config.Fodder = null;
+                    config.Variables = null;
+
+                    var configJson = CatletConfigJsonSerializer.SerializeToElement(config);
+
+                    WaitForOperation(client.Update(
+                            catlet.Id,
+                            new UpdateCatletRequestBody(configJson)
+                            {
+                                CorrelationId = Guid.NewGuid(),
+                            }),
+                        NoWait, true);
                 }
-
-                if (config.Fodder is not null || config.Variables is not null)
-                    WriteWarning("The fodder and variables cannot be changed when updating a catlet. The provided data will be ignored.");
-
-                config.Fodder = null;
-                config.Variables = null;
-
-                var configJson = CatletConfigJsonSerializer.SerializeToElement(config);
-
-                WaitForOperation(client.Update(
-                        id,
-                        new UpdateCatletRequestBody(configJson)
-                        {
-                            CorrelationId = Guid.NewGuid(),
-                        }),
-                    NoWait, true);
             }
         }
     }

--- a/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
@@ -52,6 +52,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
                             "ConfigIsNotInstanceSpecific",
                             ErrorCategory.InvalidOperation,
                             catlet.Id));
+                        continue;
                     }
 
                     if (config.Fodder is not null || config.Variables is not null)

--- a/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/UpdateCatletCommand.cs
@@ -27,14 +27,18 @@ namespace Eryph.ComputeClient.Commands.Catlets
         [Parameter]
         public SwitchParameter NoWait { get; set; }
 
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string ProjectName { get; set; }
+
         protected override void ProcessRecord()
         {
             var client = Factory.CreateCatletsClient();
 
             foreach (var nameOrId in Id)
             {
-                foreach (var catlet in ResolveByNameOrId(nameOrId, GetSingleCatlet,
-                             () => client.List(), c => c.Name, "catlet"))
+                foreach (var catlet in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatlet,
+                             projectId => client.List(projectId: projectId), c => c.Name, "catlet"))
                 {
                     if (Stopping) break;
 

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -163,6 +163,26 @@ namespace Eryph.ComputeClient.Commands
             return project.Id;
         }
 
+        /// <summary>
+        /// Resolves a project name to its id, turning an unknown/inaccessible project into
+        /// a non-terminating error (returning false) instead of a terminating exception.
+        /// A null/empty name yields a null id and true (i.e. "no project filter").
+        /// </summary>
+        protected bool TryGetProjectId(string projectName, out string projectId)
+        {
+            try
+            {
+                projectId = GetProjectId(projectName);
+                return true;
+            }
+            catch (ProjectNotFoundException ex)
+            {
+                WriteError(new ErrorRecord(ex, "ProjectNotFound", ErrorCategory.ObjectNotFound, projectName));
+                projectId = null;
+                return false;
+            }
+        }
+
         protected void ListOutput<T>(Pageable<T> pageable)
         {
             foreach (var page in pageable)
@@ -255,19 +275,7 @@ namespace Eryph.ComputeClient.Commands
                 yield break;
             }
 
-            string projectId = null;
-            var projectResolved = true;
-            try
-            {
-                projectId = GetProjectId(projectName);
-            }
-            catch (ProjectNotFoundException ex)
-            {
-                WriteError(new ErrorRecord(ex, "ProjectNotFound", ErrorCategory.ObjectNotFound, projectName));
-                projectResolved = false;
-            }
-
-            if (!projectResolved)
+            if (!TryGetProjectId(projectName, out var projectId))
                 yield break;
 
             // A wildcard may intentionally match several resources. An exact name, however,

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -185,16 +185,19 @@ namespace Eryph.ComputeClient.Commands
             Func<string, T> getById,
             Func<IEnumerable<T>> listFactory,
             Func<T, string> nameSelector,
-            string resourceKind)
+            string resourceKind,
+            Action<T> writeItem = null)
         {
+            writeItem ??= item => WriteObject(item);
+
             if (IsResourceId(nameOrId))
             {
                 if (TryGetById(nameOrId, getById, resourceKind, out var item))
-                    WriteObject(item);
+                    writeItem(item);
                 return;
             }
 
-            WriteFilteredByName(listFactory(), nameOrId, nameSelector, resourceKind);
+            WriteFilteredByName(listFactory(), nameOrId, nameSelector, resourceKind, writeItem);
         }
 
         /// <summary>
@@ -209,8 +212,11 @@ namespace Eryph.ComputeClient.Commands
             IEnumerable<T> items,
             string namePattern,
             Func<T, string> nameSelector,
-            string resourceKind)
+            string resourceKind,
+            Action<T> writeItem = null)
         {
+            writeItem ??= item => WriteObject(item);
+
             var hasWildcards = !string.IsNullOrEmpty(namePattern)
                                && WildcardPattern.ContainsWildcardCharacters(namePattern);
             var pattern = string.IsNullOrWhiteSpace(namePattern)
@@ -230,10 +236,13 @@ namespace Eryph.ComputeClient.Commands
                 }
 
                 matched = true;
-                WriteObject(item);
+                writeItem(item);
             }
 
-            if (!matched && pattern is not null && !hasWildcards)
+            // An exact name (no wildcards) that matches nothing is an error, mirroring
+            // Get-Process/Get-Service. A wildcard pattern simply returns nothing. Do not
+            // raise the error when the pipeline was stopped before a match was found.
+            if (!Stopping && !matched && pattern is not null && !hasWildcards)
                 WriteError(ResourceNotFound(resourceKind, "name", namePattern));
         }
 
@@ -260,12 +269,17 @@ namespace Eryph.ComputeClient.Commands
             }
         }
 
-        protected static ErrorRecord ResourceNotFound(string resourceKind, string by, string value) =>
-            new ErrorRecord(
+        protected static ErrorRecord ResourceNotFound(string resourceKind, string by, string value)
+        {
+            var errorId = string.Concat(resourceKind
+                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(word => char.ToUpperInvariant(word[0]) + word.Substring(1)));
+            return new ErrorRecord(
                 new ItemNotFoundException($"Cannot find a {resourceKind} with the {by} '{value}'."),
-                $"{resourceKind.Replace(" ", string.Empty)}NotFound",
+                $"{errorId}NotFound",
                 ErrorCategory.ObjectNotFound,
                 value);
+        }
 
         protected Operation WaitForOperation(Operation operation)
         {

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -232,7 +232,8 @@ namespace Eryph.ComputeClient.Commands
             Func<string, T> getById,
             Func<string, IEnumerable<T>> listInProject,
             Func<T, string> nameSelector,
-            string resourceKind)
+            string resourceKind,
+            string ambiguityHint = null)
         {
             if (IsResourceId(nameOrId))
             {
@@ -283,11 +284,13 @@ namespace Eryph.ComputeClient.Commands
             var matches = FilterByName(listInProject(projectId), nameOrId, nameSelector, resourceKind).ToList();
             if (matches.Count > 1)
             {
+                var hint = string.IsNullOrWhiteSpace(ambiguityHint)
+                    ? "Specify the id to select one."
+                    : $"Narrow the selection with {ambiguityHint} or specify the id.";
                 WriteError(new ErrorRecord(
                     new PSArgumentException(
                         $"The {resourceKind} name '{nameOrId}' is ambiguous in project '{projectName}': "
-                        + $"it matches {matches.Count} resources. Narrow the selection (e.g. with -Environment) "
-                        + "or specify the id."),
+                        + $"it matches {matches.Count} resources. {hint}"),
                     "AmbiguousNameInProject",
                     ErrorCategory.InvalidArgument,
                     nameOrId));

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -269,7 +269,33 @@ namespace Eryph.ComputeClient.Commands
             if (!projectResolved)
                 yield break;
 
-            foreach (var item in FilterByName(listInProject(projectId), nameOrId, nameSelector, resourceKind))
+            // A wildcard may intentionally match several resources. An exact name, however,
+            // must resolve to a single target before a mutation: some resource names are
+            // unique only per project + environment, so an exact name could otherwise match
+            // several resources and the command would act on all of them.
+            if (WildcardPattern.ContainsWildcardCharacters(nameOrId))
+            {
+                foreach (var item in FilterByName(listInProject(projectId), nameOrId, nameSelector, resourceKind))
+                    yield return item;
+                yield break;
+            }
+
+            var matches = FilterByName(listInProject(projectId), nameOrId, nameSelector, resourceKind).ToList();
+            if (matches.Count > 1)
+            {
+                WriteError(new ErrorRecord(
+                    new PSArgumentException(
+                        $"The {resourceKind} name '{nameOrId}' is ambiguous in project '{projectName}': "
+                        + $"it matches {matches.Count} resources. Narrow the selection (e.g. with -Environment) "
+                        + "or specify the id."),
+                    "AmbiguousNameInProject",
+                    ErrorCategory.InvalidArgument,
+                    nameOrId));
+                yield break;
+            }
+
+            // 0 matches: FilterByName already emitted the not-found error during enumeration.
+            foreach (var item in matches)
                 yield return item;
         }
 

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -182,6 +182,11 @@ namespace Eryph.ComputeClient.Commands
         /// while a wildcard pattern simply yields nothing. Used both to write results
         /// (Get-*) and to resolve action targets (Start-/Stop-/Remove-*).
         /// </summary>
+        /// <remarks>
+        /// This is a deferred iterator that calls <c>WriteError</c> while enumerating, so
+        /// it must be consumed synchronously on the pipeline thread (a foreach inside
+        /// ProcessRecord/EndProcessing). Do not capture the result and enumerate it later.
+        /// </remarks>
         protected IEnumerable<T> ResolveByNameOrId<T>(
             string nameOrId,
             Func<string, T> getById,

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -175,10 +175,74 @@ namespace Eryph.ComputeClient.Commands
             && Guid.TryParse(value, out _);
 
         /// <summary>
-        /// Resolves a positional value that may be either a resource id (a GUID) or a
-        /// name pattern and writes the result to the pipeline. A GUID is looked up by
-        /// id; otherwise the listing is filtered by name. Use this when lookup by id
-        /// and listing return the same type.
+        /// Resolves a value that may be either a resource id (a GUID) or a name pattern
+        /// into the matching resources. A GUID is looked up by id; otherwise the listing
+        /// is filtered by name. Following the convention of cmdlets like Get-Process, an
+        /// exact name (no wildcards) that matches nothing produces a not-found error,
+        /// while a wildcard pattern simply yields nothing. Used both to write results
+        /// (Get-*) and to resolve action targets (Start-/Stop-/Remove-*).
+        /// </summary>
+        protected IEnumerable<T> ResolveByNameOrId<T>(
+            string nameOrId,
+            Func<string, T> getById,
+            Func<IEnumerable<T>> listFactory,
+            Func<T, string> nameSelector,
+            string resourceKind)
+        {
+            if (IsResourceId(nameOrId))
+            {
+                if (TryGetById(nameOrId, getById, resourceKind, out var item))
+                    yield return item;
+                yield break;
+            }
+
+            foreach (var item in FilterByName(listFactory(), nameOrId, nameSelector, resourceKind))
+                yield return item;
+        }
+
+        /// <summary>
+        /// Filters a listing by a name pattern (PowerShell wildcards, case-insensitive).
+        /// An exact name (no wildcards) that matches nothing produces a not-found error;
+        /// a wildcard pattern yields nothing; a null/empty pattern yields everything.
+        /// As eryph has no server-side search, the filtering is performed client-side.
+        /// </summary>
+        protected IEnumerable<T> FilterByName<T>(
+            IEnumerable<T> items,
+            string namePattern,
+            Func<T, string> nameSelector,
+            string resourceKind)
+        {
+            var hasWildcards = !string.IsNullOrEmpty(namePattern)
+                               && WildcardPattern.ContainsWildcardCharacters(namePattern);
+            var pattern = string.IsNullOrWhiteSpace(namePattern)
+                ? null
+                : new WildcardPattern(namePattern, WildcardOptions.IgnoreCase);
+
+            var matched = false;
+            foreach (var item in items)
+            {
+                if (Stopping) yield break;
+
+                if (pattern is not null)
+                {
+                    var name = nameSelector(item);
+                    if (name is null || !pattern.IsMatch(name))
+                        continue;
+                }
+
+                matched = true;
+                yield return item;
+            }
+
+            // An exact name (no wildcards) that matches nothing is an error, mirroring
+            // Get-Process/Get-Service. A wildcard pattern simply yields nothing. Do not
+            // raise the error when the pipeline was stopped before a match was found.
+            if (!Stopping && !matched && pattern is not null && !hasWildcards)
+                WriteError(ResourceNotFound(resourceKind, "name", namePattern));
+        }
+
+        /// <summary>
+        /// Resolves a name-or-id value and writes the matching resources to the pipeline.
         /// </summary>
         protected void WriteByNameOrId<T>(
             string nameOrId,
@@ -189,24 +253,12 @@ namespace Eryph.ComputeClient.Commands
             Action<T> writeItem = null)
         {
             writeItem ??= item => WriteObject(item);
-
-            if (IsResourceId(nameOrId))
-            {
-                if (TryGetById(nameOrId, getById, resourceKind, out var item))
-                    writeItem(item);
-                return;
-            }
-
-            WriteFilteredByName(listFactory(), nameOrId, nameSelector, resourceKind, writeItem);
+            foreach (var item in ResolveByNameOrId(nameOrId, getById, listFactory, nameSelector, resourceKind))
+                writeItem(item);
         }
 
         /// <summary>
         /// Writes the items of a listing to the pipeline, filtered by a name pattern.
-        /// The pattern supports PowerShell wildcards and is matched case-insensitively.
-        /// Following the convention of cmdlets like Get-Process, an exact name (no
-        /// wildcards) that matches nothing produces a not-found error, while a wildcard
-        /// pattern simply returns nothing. A null/empty pattern returns everything.
-        /// As eryph has no server-side search, the filtering is performed client-side.
         /// </summary>
         protected void WriteFilteredByName<T>(
             IEnumerable<T> items,
@@ -216,34 +268,8 @@ namespace Eryph.ComputeClient.Commands
             Action<T> writeItem = null)
         {
             writeItem ??= item => WriteObject(item);
-
-            var hasWildcards = !string.IsNullOrEmpty(namePattern)
-                               && WildcardPattern.ContainsWildcardCharacters(namePattern);
-            var pattern = string.IsNullOrWhiteSpace(namePattern)
-                ? null
-                : new WildcardPattern(namePattern, WildcardOptions.IgnoreCase);
-
-            var matched = false;
-            foreach (var item in items)
-            {
-                if (Stopping) break;
-
-                if (pattern is not null)
-                {
-                    var name = nameSelector(item);
-                    if (name is null || !pattern.IsMatch(name))
-                        continue;
-                }
-
-                matched = true;
+            foreach (var item in FilterByName(items, namePattern, nameSelector, resourceKind))
                 writeItem(item);
-            }
-
-            // An exact name (no wildcards) that matches nothing is an error, mirroring
-            // Get-Process/Get-Service. A wildcard pattern simply returns nothing. Do not
-            // raise the error when the pipeline was stopped before a match was found.
-            if (!Stopping && !matched && pattern is not null && !hasWildcards)
-                WriteError(ResourceNotFound(resourceKind, "name", namePattern));
         }
 
         /// <summary>

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -314,9 +314,12 @@ namespace Eryph.ComputeClient.Commands
             Func<T, string> nameSelector,
             string resourceKind)
         {
+            // Only a null/empty pattern means "no filter" (yield everything). A
+            // whitespace-only value is a real (if non-matching) name, not "list all" —
+            // ValidateNotNullOrEmpty lets ' ' through, so treat it as a name to match.
             var hasWildcards = !string.IsNullOrEmpty(namePattern)
                                && WildcardPattern.ContainsWildcardCharacters(namePattern);
-            var pattern = string.IsNullOrWhiteSpace(namePattern)
+            var pattern = string.IsNullOrEmpty(namePattern)
                 ? null
                 : new WildcardPattern(namePattern, WildcardOptions.IgnoreCase);
 

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -206,6 +206,51 @@ namespace Eryph.ComputeClient.Commands
         }
 
         /// <summary>
+        /// Resolves the target(s) of a mutating cmdlet from a value that may be a resource
+        /// id (a GUID) or a name. An id is used directly. A name must be scoped to a
+        /// project (<paramref name="projectName"/> is required) so that it cannot fan out
+        /// across projects; within the project a wildcard may still match several
+        /// resources. This keeps destructive operations from acting on same-named
+        /// resources in other projects.
+        /// </summary>
+        /// <remarks>
+        /// Like <see cref="ResolveByNameOrId{T}"/> this is a deferred iterator that calls
+        /// <c>WriteError</c> while enumerating; consume it on the pipeline thread.
+        /// </remarks>
+        protected IEnumerable<T> ResolveActionTargets<T>(
+            string nameOrId,
+            string projectName,
+            Func<string, T> getById,
+            Func<string, IEnumerable<T>> listInProject,
+            Func<T, string> nameSelector,
+            string resourceKind)
+        {
+            if (IsResourceId(nameOrId))
+            {
+                if (TryGetById(nameOrId, getById, resourceKind, out var item))
+                    yield return item;
+                yield break;
+            }
+
+            if (string.IsNullOrWhiteSpace(projectName))
+            {
+                WriteError(new ErrorRecord(
+                    new PSArgumentException(
+                        $"When a {resourceKind} is identified by name, -ProjectName is required "
+                        + "so the name can be resolved within a single project. Specify -ProjectName, "
+                        + "or pass the id instead."),
+                    "ProjectNameRequiredForNameLookup",
+                    ErrorCategory.InvalidArgument,
+                    nameOrId));
+                yield break;
+            }
+
+            var projectId = GetProjectId(projectName);
+            foreach (var item in FilterByName(listInProject(projectId), nameOrId, nameSelector, resourceKind))
+                yield return item;
+        }
+
+        /// <summary>
         /// Filters a listing by a name pattern (PowerShell wildcards, case-insensitive).
         /// An exact name (no wildcards) that matches nothing produces a not-found error;
         /// a wildcard pattern yields nothing; a null/empty pattern yields everything.

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -163,6 +163,36 @@ namespace Eryph.ComputeClient.Commands
             }
         }
 
+        /// <summary>
+        /// Writes the items of a listing to the pipeline, optionally filtered by
+        /// a name pattern. The pattern supports PowerShell wildcards and is matched
+        /// case-insensitively; a pattern without wildcard characters matches exactly.
+        /// As eryph has no server-side search, the filtering is performed client-side.
+        /// </summary>
+        protected void WriteFilteredByName<T>(
+            IEnumerable<T> items,
+            string namePattern,
+            Func<T, string> nameSelector)
+        {
+            var pattern = string.IsNullOrWhiteSpace(namePattern)
+                ? null
+                : new WildcardPattern(namePattern, WildcardOptions.IgnoreCase);
+
+            foreach (var item in items)
+            {
+                if (Stopping) break;
+
+                if (pattern != null)
+                {
+                    var name = nameSelector(item);
+                    if (name is null || !pattern.IsMatch(name))
+                        continue;
+                }
+
+                WriteObject(item);
+            }
+        }
+
         protected Operation WaitForOperation(Operation operation)
         {
             var timeStamp = DateTime.Parse("2018-01-01", CultureInfo.InvariantCulture);

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -164,34 +164,108 @@ namespace Eryph.ComputeClient.Commands
         }
 
         /// <summary>
-        /// Writes the items of a listing to the pipeline, optionally filtered by
-        /// a name pattern. The pattern supports PowerShell wildcards and is matched
-        /// case-insensitively; a pattern without wildcard characters matches exactly.
+        /// Determines whether a positional value should be treated as a resource id
+        /// rather than a name. Resource ids are GUIDs; a value that parses as a GUID
+        /// and contains no wildcard characters is an id. As resource names are short,
+        /// restricted strings they can never collide with the GUID form.
+        /// </summary>
+        protected static bool IsResourceId(string value) =>
+            !string.IsNullOrWhiteSpace(value)
+            && !WildcardPattern.ContainsWildcardCharacters(value)
+            && Guid.TryParse(value, out _);
+
+        /// <summary>
+        /// Resolves a positional value that may be either a resource id (a GUID) or a
+        /// name pattern and writes the result to the pipeline. A GUID is looked up by
+        /// id; otherwise the listing is filtered by name. Use this when lookup by id
+        /// and listing return the same type.
+        /// </summary>
+        protected void WriteByNameOrId<T>(
+            string nameOrId,
+            Func<string, T> getById,
+            Func<IEnumerable<T>> listFactory,
+            Func<T, string> nameSelector,
+            string resourceKind)
+        {
+            if (IsResourceId(nameOrId))
+            {
+                if (TryGetById(nameOrId, getById, resourceKind, out var item))
+                    WriteObject(item);
+                return;
+            }
+
+            WriteFilteredByName(listFactory(), nameOrId, nameSelector, resourceKind);
+        }
+
+        /// <summary>
+        /// Writes the items of a listing to the pipeline, filtered by a name pattern.
+        /// The pattern supports PowerShell wildcards and is matched case-insensitively.
+        /// Following the convention of cmdlets like Get-Process, an exact name (no
+        /// wildcards) that matches nothing produces a not-found error, while a wildcard
+        /// pattern simply returns nothing. A null/empty pattern returns everything.
         /// As eryph has no server-side search, the filtering is performed client-side.
         /// </summary>
         protected void WriteFilteredByName<T>(
             IEnumerable<T> items,
             string namePattern,
-            Func<T, string> nameSelector)
+            Func<T, string> nameSelector,
+            string resourceKind)
         {
+            var hasWildcards = !string.IsNullOrEmpty(namePattern)
+                               && WildcardPattern.ContainsWildcardCharacters(namePattern);
             var pattern = string.IsNullOrWhiteSpace(namePattern)
                 ? null
                 : new WildcardPattern(namePattern, WildcardOptions.IgnoreCase);
 
+            var matched = false;
             foreach (var item in items)
             {
                 if (Stopping) break;
 
-                if (pattern != null)
+                if (pattern is not null)
                 {
                     var name = nameSelector(item);
                     if (name is null || !pattern.IsMatch(name))
                         continue;
                 }
 
+                matched = true;
                 WriteObject(item);
             }
+
+            if (!matched && pattern is not null && !hasWildcards)
+                WriteError(ResourceNotFound(resourceKind, "name", namePattern));
         }
+
+        /// <summary>
+        /// Looks up a resource by id, translating a 404 into a friendly non-terminating
+        /// not-found error instead of leaking a <see cref="RequestFailedException"/>.
+        /// </summary>
+        protected bool TryGetById<T>(
+            string id,
+            Func<string, T> getById,
+            string resourceKind,
+            out T item)
+        {
+            try
+            {
+                item = getById(id);
+                return true;
+            }
+            catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
+            {
+                WriteError(ResourceNotFound(resourceKind, "id", id));
+                item = default;
+                return false;
+            }
+        }
+
+        protected static ErrorRecord ResourceNotFound(string resourceKind, string by, string value) =>
+            new ErrorRecord(
+                new ItemNotFoundException($"Cannot find a {resourceKind} with the {by} '{value}'."),
+                $"{resourceKind.Replace(" ", string.Empty)}NotFound",
+                ErrorCategory.ObjectNotFound,
+                value);
 
         protected Operation WaitForOperation(Operation operation)
         {

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -145,13 +145,22 @@ namespace Eryph.ComputeClient.Commands
             WriteObject(resource);
         }
 
+        private readonly Dictionary<string, string> _projectIdCache = new();
+
         protected string GetProjectId(string projectName)
         {
             if (string.IsNullOrWhiteSpace(projectName))
                 return null;
 
+            if (_projectIdCache.TryGetValue(projectName, out var cachedId))
+                return cachedId;
+
             var project = Factory.CreateProjectsClient().List().FirstOrDefault(x => x.Name == projectName);
-            return project == null ? throw new ProjectNotFoundException(projectName) : project.Id;
+            if (project == null)
+                throw new ProjectNotFoundException(projectName);
+
+            _projectIdCache[projectName] = project.Id;
+            return project.Id;
         }
 
         protected void ListOutput<T>(Pageable<T> pageable)
@@ -245,7 +254,21 @@ namespace Eryph.ComputeClient.Commands
                 yield break;
             }
 
-            var projectId = GetProjectId(projectName);
+            string projectId = null;
+            var projectResolved = true;
+            try
+            {
+                projectId = GetProjectId(projectName);
+            }
+            catch (ProjectNotFoundException ex)
+            {
+                WriteError(new ErrorRecord(ex, "ProjectNotFound", ErrorCategory.ObjectNotFound, projectName));
+                projectResolved = false;
+            }
+
+            if (!projectResolved)
+                yield break;
+
             foreach (var item in FilterByName(listInProject(projectId), nameOrId, nameSelector, resourceKind))
                 yield return item;
         }
@@ -337,9 +360,14 @@ namespace Eryph.ComputeClient.Commands
                 item = getById(id);
                 return true;
             }
-            catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
+            catch (RequestFailedException ex)
             {
-                WriteError(ResourceNotFound(resourceKind, "id", id));
+                // 404 becomes a friendly not-found; other server errors (e.g. 403, 500)
+                // are still surfaced as non-terminating so a loop over several ids can
+                // continue, mirroring the previous behaviour.
+                WriteError(ex.Status == (int)HttpStatusCode.NotFound
+                    ? ResourceNotFound(resourceKind, "id", id)
+                    : new ErrorRecord(ex, "RequestFailed", ErrorCategory.NotSpecified, id));
                 item = default;
                 return false;
             }

--- a/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
@@ -10,21 +10,20 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Genes;
 
 [PublicAPI]
-[Cmdlet(VerbsCommon.Get, "CatletGene", DefaultParameterSetName = "get")]
+[Cmdlet(VerbsCommon.Get, "CatletGene", DefaultParameterSetName = "list")]
 [OutputType(typeof(GeneWithUsage), ParameterSetName = ["get"])]
-[OutputType(typeof(Gene), ParameterSetName = ["list"])]
+[OutputType(typeof(Gene), typeof(GeneWithUsage), ParameterSetName = ["list"])]
 public class GetCatletGeneCmdlet : CatletGeneCmdlet
 {
     [Parameter(
         ParameterSetName = "get",
-        Position = 0,
         ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true)]
     public string[] Id { get; set; }
 
     [Parameter(
         ParameterSetName = "list",
-        ValueFromPipelineByPropertyName = true)]
+        Position = 0)]
     [ValidateNotNullOrEmpty]
     public string Name { get; set; }
 
@@ -40,9 +39,20 @@ public class GetCatletGeneCmdlet : CatletGeneCmdlet
         {
             foreach (var id in Id)
             {
-                WriteObject(GetSingleGene(id));
+                if (Stopping) break;
+                if (TryGetById(id, GetSingleGene, "gene", out var gene))
+                    WriteObject(gene);
             }
 
+            return;
+        }
+
+        // A positional GUID is a gene record id; look it up directly (returns the
+        // richer GeneWithUsage), mirroring -Id.
+        if (IsResourceId(Name))
+        {
+            if (TryGetById(Name, GetSingleGene, "gene", out var geneById))
+                WriteObject(geneById);
             return;
         }
 
@@ -53,6 +63,6 @@ public class GetCatletGeneCmdlet : CatletGeneCmdlet
             genes = genes.Where(gene =>
                 string.Equals(gene.Architecture, Architecture, StringComparison.OrdinalIgnoreCase));
 
-        WriteFilteredByName(genes, Name, gene => gene.Name);
+        WriteFilteredByName(genes, Name, gene => gene.Name, "gene");
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
@@ -27,9 +27,7 @@ public class GetCatletGeneCmdlet : CatletGeneCmdlet
     [ValidateNotNullOrEmpty]
     public string Name { get; set; }
 
-    [Parameter(
-        ParameterSetName = "list",
-        ValueFromPipelineByPropertyName = true)]
+    [Parameter(ParameterSetName = "list")]
     [ValidateNotNullOrEmpty]
     public string Architecture { get; set; }
 

--- a/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
@@ -22,6 +22,18 @@ public class GetCatletGeneCmdlet : CatletGeneCmdlet
         ValueFromPipelineByPropertyName = true)]
     public string[] Id { get; set; }
 
+    [Parameter(
+        ParameterSetName = "list",
+        ValueFromPipelineByPropertyName = true)]
+    [ValidateNotNullOrEmpty]
+    public string Name { get; set; }
+
+    [Parameter(
+        ParameterSetName = "list",
+        ValueFromPipelineByPropertyName = true)]
+    [ValidateNotNullOrEmpty]
+    public string Architecture { get; set; }
+
     protected override void ProcessRecord()
     {
         if (Id != null)
@@ -34,10 +46,13 @@ public class GetCatletGeneCmdlet : CatletGeneCmdlet
             return;
         }
 
-        foreach (var gene in Factory.CreateGenesClient().List())
-        {
-            if (Stopping) break;
-            WriteObject(gene, true);
-        }
+        // Genes list globally and are identified by GeneSet + Name + Architecture.
+        // Architecture is an exact (case-insensitive) filter; Name supports wildcards.
+        IEnumerable<Gene> genes = Factory.CreateGenesClient().List();
+        if (!string.IsNullOrWhiteSpace(Architecture))
+            genes = genes.Where(gene =>
+                string.Equals(gene.Architecture, Architecture, StringComparison.OrdinalIgnoreCase));
+
+        WriteFilteredByName(genes, Name, gene => gene.Name);
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Networks/GetVNetworksCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Networks/GetVNetworksCommand.cs
@@ -44,6 +44,7 @@ namespace Eryph.ComputeClient.Commands.Networks
         [Parameter(
             ParameterSetName = "getconfig",
             Mandatory = true,
+            ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         [Parameter(
             ParameterSetName = "list",

--- a/src/Eryph.ComputeClient.Commands/Networks/GetVNetworksCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Networks/GetVNetworksCommand.cs
@@ -53,7 +53,8 @@ namespace Eryph.ComputeClient.Commands.Networks
 
         protected override void ProcessRecord()
         {
-            var projectId = GetProjectId(ProjectName);
+            if (!TryGetProjectId(ProjectName, out var projectId))
+                return;
 
             if (Config.IsPresent)
             {

--- a/src/Eryph.ComputeClient.Commands/Networks/GetVNetworksCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Networks/GetVNetworksCommand.cs
@@ -1,4 +1,7 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
 using Eryph.ComputeClient.Models;
 using Eryph.ConfigModel.Json;
 using Eryph.ConfigModel.Networks;
@@ -8,14 +11,14 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Networks
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.Get, "VNetwork", DefaultParameterSetName = "get")]
+    [Cmdlet(VerbsCommon.Get, "VNetwork", DefaultParameterSetName = "list")]
     [OutputType(typeof(VirtualNetwork), ParameterSetName = new[] { "get" })]
+    [OutputType(typeof(VirtualNetwork), ParameterSetName = new[] { "list" })]
     [OutputType(typeof(string), ParameterSetName = new[] { "getconfig" })]
     public class GetVNetworksCommand : NetworkCmdLet
     {
         [Parameter(
             ParameterSetName = "get",
-            Position = 0,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         public string[] Id { get; set; }
@@ -26,12 +29,24 @@ namespace Eryph.ComputeClient.Commands.Networks
         public SwitchParameter Config { get; set; }
 
         [Parameter(
+            ParameterSetName = "list",
+            Position = 0)]
+        [ValidateNotNullOrEmpty]
+        public string Name { get; set; }
+
+        [Parameter(ParameterSetName = "list")]
+        [ValidateNotNullOrEmpty]
+        public string Environment { get; set; }
+
+        [Parameter(
             ParameterSetName = "get",
             ValueFromPipelineByPropertyName = true)]
         [Parameter(
             ParameterSetName = "getconfig",
             Mandatory = true,
-            ValueFromPipeline = true,
+            ValueFromPipelineByPropertyName = true)]
+        [Parameter(
+            ParameterSetName = "list",
             ValueFromPipelineByPropertyName = true)]
         public string ProjectName { get; set; }
 
@@ -41,25 +56,30 @@ namespace Eryph.ComputeClient.Commands.Networks
 
             if (Config.IsPresent)
             {
-
                 WriteConfig(Factory.CreateVirtualNetworksClient().GetConfig(projectId).Value);
                 return;
             }
-
 
             if (Id != null)
             {
                 foreach (var id in Id)
                 {
-                    WriteObject(GetSingleNetwork(id));
+                    if (Stopping) break;
+                    if (TryGetById(id, GetSingleNetwork, "virtual network", out var network))
+                        WriteObject(network);
                 }
 
                 return;
             }
 
+            // Network names are unique per project + environment, so allow narrowing by
+            // environment. The environment filter is applied to the listing; an explicit
+            // id (GUID) ignores it.
+            IEnumerable<VirtualNetwork> networks = Factory.CreateVirtualNetworksClient().List(projectId: projectId);
+            if (!string.IsNullOrWhiteSpace(Environment))
+                networks = networks.Where(n => string.Equals(n.Environment, Environment, StringComparison.OrdinalIgnoreCase));
 
-            ListOutput(Factory.CreateVirtualNetworksClient().List(projectId: projectId));
-
+            WriteByNameOrId(Name, GetSingleNetwork, () => networks, n => n.Name, "virtual network");
         }
 
         private void WriteConfig(VirtualNetworkConfiguration config)

--- a/src/Eryph.ComputeClient.Commands/Projects/GetEryphProjectCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Projects/GetEryphProjectCommand.cs
@@ -7,20 +7,19 @@ using JetBrains.Annotations;
 namespace Eryph.ComputeClient.Commands.Projects
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.Get, "EryphProject", DefaultParameterSetName = "get")]
+    [Cmdlet(VerbsCommon.Get, "EryphProject", DefaultParameterSetName = "list")]
     [OutputType(typeof(Project))]
     public class GetEryphProjectCommand : ProjectCmdlet
     {
         [Parameter(
             ParameterSetName = "get",
-            Position = 0,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         public string[] Id { get; set; }
 
         [Parameter(
             ParameterSetName = "list",
-            ValueFromPipelineByPropertyName = true)]
+            Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Name { get; set; }
 
@@ -30,16 +29,20 @@ namespace Eryph.ComputeClient.Commands.Projects
             {
                 foreach (var id in Id)
                 {
-                    WriteObject(Factory.CreateProjectsClient().Get(id).Value);
+                    if (Stopping) break;
+                    if (TryGetById(id, i => Factory.CreateProjectsClient().Get(i).Value, "project", out var project))
+                        WriteObject(project);
                 }
 
                 return;
             }
 
-            WriteFilteredByName(
-                Factory.CreateProjectsClient().List(),
+            WriteByNameOrId(
                 Name,
-                project => project.Name);
+                id => Factory.CreateProjectsClient().Get(id).Value,
+                () => Factory.CreateProjectsClient().List(),
+                project => project.Name,
+                "project");
         }
 
 

--- a/src/Eryph.ComputeClient.Commands/Projects/GetEryphProjectCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Projects/GetEryphProjectCommand.cs
@@ -18,6 +18,12 @@ namespace Eryph.ComputeClient.Commands.Projects
             ValueFromPipelineByPropertyName = true)]
         public string[] Id { get; set; }
 
+        [Parameter(
+            ParameterSetName = "list",
+            ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty]
+        public string Name { get; set; }
+
         protected override void ProcessRecord()
         {
             if (Id != null)
@@ -30,9 +36,10 @@ namespace Eryph.ComputeClient.Commands.Projects
                 return;
             }
 
-            ListOutput(Factory.CreateProjectsClient().List());
-
-
+            WriteFilteredByName(
+                Factory.CreateProjectsClient().List(),
+                Name,
+                project => project.Name);
         }
 
 

--- a/src/Eryph.ComputeClient.Commands/Projects/RemoveProjectCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Projects/RemoveProjectCommand.cs
@@ -15,6 +15,7 @@ public class RemoveProjectCommand : ProjectCmdlet
         ValueFromPipeline = true,
         Mandatory = true,
         ValueFromPipelineByPropertyName = true)]
+    [Alias("Name")]
     public string[] Id { get; set; }
 
     [Parameter]
@@ -28,26 +29,23 @@ public class RemoveProjectCommand : ProjectCmdlet
 
     protected override void ProcessRecord()
     {
-        foreach (var id in Id)
+        foreach (var nameOrId in Id)
         {
-            Project project;
-            try
+            foreach (var project in ResolveByNameOrId(nameOrId,
+                         id => Factory.CreateProjectsClient().Get(id).Value,
+                         () => Factory.CreateProjectsClient().List(),
+                         p => p.Name, "project"))
             {
-                project = Factory.CreateProjectsClient().Get(id);
-            }
-            catch (Exception ex)
-            {
-                WriteError(new ErrorRecord(ex, "ProjectNotFound", ErrorCategory.ObjectNotFound, id));
-                continue;
-            }
+                if (Stopping) break;
 
-            if (!Force && !ShouldContinue($"Project '{project.Name}' (Id:{id}) and all catlets in the project will be deleted!", "Warning!",
-                    ref _yesToAll, ref _noToAll))
-            {
-                continue;
-            }
+                if (!Force && !ShouldContinue($"Project '{project.Name}' (Id:{project.Id}) and all catlets in the project will be deleted!", "Warning!",
+                        ref _yesToAll, ref _noToAll))
+                {
+                    continue;
+                }
 
-            WaitForProject(Factory.CreateProjectsClient().Delete(id), NoWait, false, id);
+                WaitForProject(Factory.CreateProjectsClient().Delete(project.Id), NoWait, false, project.Id);
+            }
         }
     }
 }

--- a/test/pester/Invoke-PesterTests.ps1
+++ b/test/pester/Invoke-PesterTests.ps1
@@ -37,6 +37,10 @@ if (-not $pester) {
 }
 Import-Module $pester.Path -Force
 
+# Make the selected build configuration available to the test discovery so it
+# imports the matching build instead of merely the newest one on disk.
+$env:ERYPH_TEST_CONFIGURATION = $Configuration
+
 $config = New-PesterConfiguration
 $config.Run.Path = $PSScriptRoot
 $config.Output.Verbosity = 'Detailed'

--- a/test/pester/Invoke-PesterTests.ps1
+++ b/test/pester/Invoke-PesterTests.ps1
@@ -1,0 +1,45 @@
+#Requires -Version 7.4
+<#
+    .SYNOPSIS
+        Runs the Pester tests for the Eryph.ComputeClient module.
+    .DESCRIPTION
+        Optionally (re)builds the PowerShell module, then runs the Pester tests in
+        this folder. The "parameter surface" tests run without a server; the
+        integration tests run only when a local eryph is reachable and are skipped
+        otherwise.
+    .EXAMPLE
+        ./Invoke-PesterTests.ps1 -Build
+        Builds the module and runs all tests.
+#>
+[CmdletBinding()]
+param(
+    # Build the Commands project before running the tests.
+    [switch] $Build,
+    # Build configuration to use when -Build is set / when locating the module.
+    [string] $Configuration = 'Debug'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
+
+if ($Build) {
+    $csproj = Join-Path $repoRoot 'src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj'
+    Write-Host "Building $csproj ($Configuration)..." -ForegroundColor Cyan
+    dotnet build $csproj -c $Configuration
+    if ($LASTEXITCODE -ne 0) { throw "Build failed with exit code $LASTEXITCODE." }
+}
+
+# Pester v5 is required.
+$pester = Get-Module Pester -ListAvailable | Where-Object Version -ge ([version]'5.0.0') |
+    Sort-Object Version -Descending | Select-Object -First 1
+if (-not $pester) {
+    throw "Pester 5+ is required. Install it with: Install-Module Pester -MinimumVersion 5.0.0 -Scope CurrentUser"
+}
+Import-Module $pester.Path -Force
+
+$config = New-PesterConfiguration
+$config.Run.Path = $PSScriptRoot
+$config.Output.Verbosity = 'Detailed'
+$config.Run.Exit = $true
+
+Invoke-Pester -Configuration $config

--- a/test/pester/README.md
+++ b/test/pester/README.md
@@ -6,8 +6,8 @@ the name-based lookup feature (issue #69).
 ## Layers
 
 1. **Parameter surface** — verifies cmdlets expose `-Name` in the `list`
-   parameter set, that it is a string and not positional. Needs **no server**
-   and is safe to run in CI.
+   parameter set, that it is a string and is positional (position 0). Needs
+   **no server** and is safe to run in CI.
 2. **Integration** — exercises the real cmdlet → HTTP → client-side filter path
    against a running eryph. These create a throwaway project (and read existing
    catlets) to assert exact / wildcard / case-insensitive matching and the

--- a/test/pester/README.md
+++ b/test/pester/README.md
@@ -34,8 +34,11 @@ The integration tests use the ambient eryph credentials (e.g. the eryph-zero
 system-client — run as Administrator on Windows). When no eryph is reachable
 only the parameter-surface tests run.
 
-Requires Pester 5+:
+Requirements:
 
-```powershell
-Install-Module Pester -MinimumVersion 5.0.0 -Scope CurrentUser
-```
+- **PowerShell 7.4+** — the `Invoke-PesterTests.ps1` runner declares `#Requires -Version 7.4`. The tests themselves run under Windows PowerShell 5.1 too (the module's `desktop` build), but use the runner from pwsh 7.4+.
+- **Pester 5+**:
+
+  ```powershell
+  Install-Module Pester -MinimumVersion 5.0.0 -Scope CurrentUser
+  ```

--- a/test/pester/README.md
+++ b/test/pester/README.md
@@ -1,0 +1,41 @@
+# Pester tests
+
+PowerShell (Pester v5) tests for the `Eryph.ComputeClient` cmdlets, focused on
+the name-based lookup feature (issue #69).
+
+## Layers
+
+1. **Parameter surface** — verifies cmdlets expose `-Name` in the `list`
+   parameter set, that it is a string and not positional. Needs **no server**
+   and is safe to run in CI.
+2. **Integration** — exercises the real cmdlet → HTTP → client-side filter path
+   against a running eryph. These create a throwaway project (and read existing
+   catlets) to assert exact / wildcard / case-insensitive matching and the
+   empty-result case, then clean up. They are **skipped automatically** when no
+   eryph is reachable.
+
+> A fully server-less end-to-end test isn't practical here: the cmdlets use the
+> eryph client-credentials OAuth flow plus on-disk configuration, so faking the
+> backend would mean stubbing the identity *and* compute endpoints and a config
+> store. The parameter-surface layer gives deterministic CI coverage; the
+> integration layer gives real-world behavior when an eryph is present.
+
+## Running
+
+```powershell
+# build the module and run everything
+./Invoke-PesterTests.ps1 -Build
+
+# run against an already-built module
+./Invoke-PesterTests.ps1
+```
+
+The integration tests use the ambient eryph credentials (e.g. the eryph-zero
+system-client — run as Administrator on Windows). When no eryph is reachable
+only the parameter-surface tests run.
+
+Requires Pester 5+:
+
+```powershell
+Install-Module Pester -MinimumVersion 5.0.0 -Scope CurrentUser
+```

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -40,9 +40,13 @@ Describe 'Get-* -Name parameter surface (no server required)' {
         $p.ParameterSets.Keys | Should -Contain 'list'
     }
 
-    It '-Name on Get-Catlet is not positional (must not clash with -Id)' {
-        (Get-Command Get-Catlet).Parameters['Name'].ParameterSets['list'].Position |
-            Should -BeLessThan 0
+    It "<Cmd> takes -Name as positional parameter 0" -ForEach @(
+        @{ Cmd = 'Get-Catlet' }
+        @{ Cmd = 'Get-EryphProject' }
+        @{ Cmd = 'Get-CatletSpecification' }
+        @{ Cmd = 'Get-CatletGene' }
+    ) {
+        (Get-Command $Cmd).Parameters['Name'].ParameterSets['list'].Position | Should -Be 0
     }
 
     It "Get-CatletGene exposes an -Architecture filter in the 'list' set" {
@@ -52,13 +56,14 @@ Describe 'Get-* -Name parameter surface (no server required)' {
     }
 }
 
-Describe 'Get-EryphProject -Name (integration)' -Skip:(-not $eryphAvailable) {
+Describe 'Get-EryphProject name-or-id (integration)' -Skip:(-not $eryphAvailable) {
 
     BeforeAll {
         # Project names are limited to 20 chars, so keep the prefix short.
-        $prefix = "pst$([guid]::NewGuid().ToString('N').Substring(0,6))"  # 9 chars
-        $names  = "$prefix-a", "$prefix-b", "$prefix-c"
+        $prefix  = "pst$([guid]::NewGuid().ToString('N').Substring(0,6))"  # 9 chars
+        $names   = "$prefix-a", "$prefix-b", "$prefix-c"
         foreach ($n in $names) { $null = New-EryphProject -Name $n }
+        $created = @(Get-EryphProject -Name "$prefix-*")
     }
 
     AfterAll {
@@ -68,24 +73,37 @@ Describe 'Get-EryphProject -Name (integration)' -Skip:(-not $eryphAvailable) {
         }
     }
 
-    It 'matches an exact name' {
+    It 'matches an exact name (named)' {
         (Get-EryphProject -Name "$prefix-a").Name | Should -Be "$prefix-a"
     }
 
+    It 'matches an exact name positionally' {
+        (Get-EryphProject "$prefix-a").Name | Should -Be "$prefix-a"
+    }
+
+    It 'resolves a positional GUID to an id lookup' {
+        $one = $created | Select-Object -First 1
+        (Get-EryphProject $one.Id).Id | Should -Be $one.Id
+    }
+
     It 'matches a wildcard pattern' {
-        (Get-EryphProject -Name "$prefix-*" | Measure-Object).Count | Should -Be 3
+        (Get-EryphProject "$prefix-*" | Measure-Object).Count | Should -Be 3
     }
 
     It 'matches case-insensitively' {
-        (Get-EryphProject -Name "$prefix-A").Name | Should -Be "$prefix-a"
+        (Get-EryphProject "$prefix-A").Name | Should -Be "$prefix-a"
     }
 
-    It 'returns nothing when no project matches' {
-        Get-EryphProject -Name "$prefix-z" | Should -BeNullOrEmpty
+    It 'errors on an exact name that does not exist (Get-Process convention)' {
+        { Get-EryphProject -Name "$prefix-z" -ErrorAction Stop } | Should -Throw
+    }
+
+    It 'returns nothing for a wildcard with no match' {
+        Get-EryphProject -Name "$prefix-z*" | Should -BeNullOrEmpty
     }
 }
 
-Describe 'Get-Catlet -Name (integration, read-only)' -Skip:(-not $eryphAvailable) {
+Describe 'Get-Catlet name-or-id (integration, read-only)' -Skip:(-not $eryphAvailable) {
 
     BeforeAll { $existing = @(Get-Catlet) }
 
@@ -95,13 +113,23 @@ Describe 'Get-Catlet -Name (integration, read-only)' -Skip:(-not $eryphAvailable
         Get-Catlet -Name $sample | ForEach-Object { $_.Name | Should -BeLike $sample }
     }
 
+    It 'resolves a positional GUID to an id lookup' {
+        if ($existing.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlets present'; return }
+        $one = $existing[0]
+        (Get-Catlet $one.Id).Id | Should -Be $one.Id
+    }
+
     It "wildcard '*' returns every catlet" {
         if ($existing.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlets present'; return }
         (Get-Catlet -Name '*' | Measure-Object).Count | Should -Be $existing.Count
     }
 
-    It 'returns nothing for a non-existent name' {
-        Get-Catlet -Name "zzz-$([guid]::NewGuid().ToString('N'))" | Should -BeNullOrEmpty
+    It 'errors on an exact name that does not exist' {
+        { Get-Catlet -Name "zzz-$([guid]::NewGuid().ToString('N'))" -ErrorAction Stop } | Should -Throw
+    }
+
+    It 'returns nothing for a wildcard with no match' {
+        Get-Catlet -Name "zzzz-no-such-catlet-*" | Should -BeNullOrEmpty
     }
 }
 
@@ -119,5 +147,11 @@ Describe 'Get-CatletGene -Name / -Architecture (integration, read-only)' -Skip:(
         if ($genes.Count -eq 0) { Set-ItResult -Skipped -Because 'no genes present'; return }
         $arch = $genes[0].Architecture
         Get-CatletGene -Architecture $arch | ForEach-Object { $_.Architecture | Should -Be $arch }
+    }
+
+    It 'resolves a positional GUID to a gene record (GeneWithUsage)' {
+        if ($genes.Count -eq 0) { Set-ItResult -Skipped -Because 'no genes present'; return }
+        $one = $genes[0]
+        (Get-CatletGene $one.Id).Id | Should -Be $one.Id
     }
 }

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -231,10 +231,19 @@ Describe 'Get-VNetwork name-or-id / -Environment (integration, read-only)' -Skip
         Get-VNetwork -Name $sample | ForEach-Object { $_.Name | Should -BeExactly $sample }
     }
 
-    It 'filters networks by environment' {
+    It 'filters networks by environment (and excludes other environments)' {
         if ($networks.Count -eq 0) { Set-ItResult -Skipped -Because 'no networks present'; return }
         $environment = $networks[0].Environment
-        Get-VNetwork -Environment $environment | ForEach-Object { $_.Environment | Should -Be $environment }
+        $filtered = @(Get-VNetwork -Environment $environment)
+        $filtered | ForEach-Object { $_.Environment | Should -Be $environment }
+        $expected = @($networks | Where-Object Environment -EQ $environment).Count
+        $filtered.Count | Should -Be $expected
+    }
+
+    It '-Config returns the project network configuration as a string' {
+        $config = Get-VNetwork -Config -ProjectName 'default'
+        $config | Should -Not -BeNullOrEmpty
+        $config | Should -BeOfType [string]
     }
 
     It 'resolves a positional GUID to an id lookup' {
@@ -254,10 +263,13 @@ Describe 'Get-CatletDisk name-or-id / -Environment (integration, read-only)' -Sk
         Get-CatletDisk -Name $sample | ForEach-Object { $_.Name | Should -BeExactly $sample }
     }
 
-    It 'filters disks by environment' {
+    It 'filters disks by environment (and excludes other environments)' {
         if ($disks.Count -eq 0) { Set-ItResult -Skipped -Because 'no disks present'; return }
         $environment = $disks[0].Environment
-        Get-CatletDisk -Environment $environment | ForEach-Object { $_.Environment | Should -Be $environment }
+        $filtered = @(Get-CatletDisk -Environment $environment)
+        $filtered | ForEach-Object { $_.Environment | Should -Be $environment }
+        $expected = @($disks | Where-Object Environment -EQ $environment).Count
+        $filtered.Count | Should -Be $expected
     }
 
     It 'resolves a positional GUID to an id lookup' {

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -215,6 +215,14 @@ Describe 'Get-Catlet name-or-id (integration, read-only)' -Skip:(-not $eryphAvai
         { Get-Catlet -Name '   ' -ErrorAction Stop } | Should -Throw
     }
 
+    It 'reports an unknown -ProjectName as a non-terminating error' {
+        $bad = "no-such-project-$([guid]::NewGuid().ToString('N').Substring(0,6))"
+        # Non-terminating: SilentlyContinue suppresses it without throwing...
+        { Get-Catlet -ProjectName $bad -ErrorAction SilentlyContinue } | Should -Not -Throw
+        # ...but it is a real error, surfaced when -ErrorAction Stop is used.
+        { Get-Catlet -ProjectName $bad -ErrorAction Stop } | Should -Throw
+    }
+
     It '-Config (without -Id) returns YAML config strings, not catlet objects' {
         if ($existing.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlets present'; return }
         $config = @(Get-Catlet -Config)

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -125,6 +125,10 @@ Describe 'Action cmdlets accept name-or-id (parameter surface)' {
     ) {
         (Get-Command $Cmd).Parameters['ProjectName'] | Should -Not -BeNullOrEmpty
     }
+
+    It 'Remove-CatletDisk exposes an -Environment scope (disk names are unique per project + environment)' {
+        (Get-Command Remove-CatletDisk).Parameters['Environment'] | Should -Not -BeNullOrEmpty
+    }
 }
 
 Describe 'Get-EryphProject name-or-id (integration)' -Skip:(-not $eryphAvailable) {

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -209,6 +209,12 @@ Describe 'Get-Catlet name-or-id (integration, read-only)' -Skip:(-not $eryphAvai
         Get-Catlet -Name "zzzz-no-such-catlet-*" | Should -BeNullOrEmpty
     }
 
+    It 'treats a whitespace-only name as a name (not "list all")' {
+        # '   ' must not be interpreted as an omitted filter; it is an exact,
+        # non-matching name and so produces a not-found error, not every catlet.
+        { Get-Catlet -Name '   ' -ErrorAction Stop } | Should -Throw
+    }
+
     It '-Config (without -Id) returns YAML config strings, not catlet objects' {
         if ($existing.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlets present'; return }
         $config = @(Get-Catlet -Config)

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -58,6 +58,35 @@ Describe 'Get-* -Name parameter surface (no server required)' {
     }
 }
 
+Describe 'Action cmdlets accept name-or-id (parameter surface)' {
+
+    It "<Cmd> exposes a 'Name' alias on -Id" -ForEach @(
+        @{ Cmd = 'Start-Catlet' }
+        @{ Cmd = 'Stop-Catlet' }
+        @{ Cmd = 'Remove-Catlet' }
+        @{ Cmd = 'Update-Catlet' }
+        @{ Cmd = 'Remove-CatletDisk' }
+        @{ Cmd = 'Remove-CatletSpecification' }
+        @{ Cmd = 'Update-CatletSpecification' }
+        @{ Cmd = 'Remove-EryphProject' }
+    ) {
+        (Get-Command $Cmd).Parameters['Id'].Aliases | Should -Contain 'Name'
+    }
+
+    It "<Cmd> takes its id/name target as positional parameter 0" -ForEach @(
+        @{ Cmd = 'Start-Catlet' }
+        @{ Cmd = 'Stop-Catlet' }
+        @{ Cmd = 'Remove-Catlet' }
+        @{ Cmd = 'Update-Catlet' }
+        @{ Cmd = 'Remove-CatletDisk' }
+        @{ Cmd = 'Remove-CatletSpecification' }
+        @{ Cmd = 'Remove-EryphProject' }
+    ) {
+        $positions = (Get-Command $Cmd).Parameters['Id'].ParameterSets.Values.Position
+        $positions | Should -Contain 0
+    }
+}
+
 Describe 'Get-EryphProject name-or-id (integration)' -Skip:(-not $eryphAvailable) {
 
     BeforeAll {
@@ -158,6 +187,17 @@ Describe 'Get-CatletIp name-or-id (integration, read-only)' -Skip:(-not $eryphAv
         if ($withIp.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlet has an IP'; return }
         $one = $withIp[0]
         Get-CatletIp $one.Id | ForEach-Object { $_.Id | Should -Be $one.Id }
+    }
+}
+
+Describe 'Action cmdlets name resolution (integration, non-destructive)' -Skip:(-not $eryphAvailable) {
+
+    It 'Start-Catlet errors on a non-existent exact name (nothing is started)' {
+        { Start-Catlet -Name "zzz-$([guid]::NewGuid().ToString('N'))" -ErrorAction Stop } | Should -Throw
+    }
+
+    It 'Remove-Catlet with a non-matching wildcard does nothing and does not error' {
+        { Remove-Catlet -Name 'zzzz-no-such-catlet-*' -Force -ErrorAction Stop } | Should -Not -Throw
     }
 }
 

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -72,6 +72,18 @@ Describe 'Get-* -Name parameter surface (no server required)' {
         $p | Should -Not -BeNullOrEmpty
         $p.ParameterSets.Keys | Should -Contain 'list'
     }
+
+    It "<Cmd> exposes an optional -ProjectName filter in the 'list' set" -ForEach @(
+        @{ Cmd = 'Get-Catlet' }
+        @{ Cmd = 'Get-CatletDisk' }
+        @{ Cmd = 'Get-CatletIp' }
+        @{ Cmd = 'Get-VNetwork' }
+        @{ Cmd = 'Get-CatletSpecification' }
+    ) {
+        $p = (Get-Command $Cmd).Parameters['ProjectName']
+        $p | Should -Not -BeNullOrEmpty
+        $p.ParameterSets['list'].IsMandatory | Should -BeFalse
+    }
 }
 
 Describe 'Action cmdlets accept name-or-id (parameter surface)' {

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -248,6 +248,11 @@ Describe 'Action cmdlets name resolution (integration, non-destructive)' -Skip:(
             Should -Throw -ExpectedMessage '*Cannot find*'
     }
 
+    It 'errors when -ProjectName does not exist (nothing is started)' {
+        { Start-Catlet -Name 'web' -ProjectName "no-such-project-$([guid]::NewGuid().ToString('N').Substring(0,6))" -ErrorAction Stop } |
+            Should -Throw
+    }
+
     It 'Start-Catlet errors on a non-existent exact name within a project (nothing is started)' {
         { Start-Catlet -Name "zzz-$([guid]::NewGuid().ToString('N'))" -ProjectName 'default' -ErrorAction Stop } |
             Should -Throw

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -33,6 +33,7 @@ Describe 'Get-* -Name parameter surface (no server required)' {
         @{ Cmd = 'Get-EryphProject' }
         @{ Cmd = 'Get-CatletSpecification' }
         @{ Cmd = 'Get-CatletGene' }
+        @{ Cmd = 'Get-CatletIp' }
     ) {
         $p = (Get-Command $Cmd).Parameters['Name']
         $p | Should -Not -BeNullOrEmpty
@@ -45,6 +46,7 @@ Describe 'Get-* -Name parameter surface (no server required)' {
         @{ Cmd = 'Get-EryphProject' }
         @{ Cmd = 'Get-CatletSpecification' }
         @{ Cmd = 'Get-CatletGene' }
+        @{ Cmd = 'Get-CatletIp' }
     ) {
         (Get-Command $Cmd).Parameters['Name'].ParameterSets['list'].Position | Should -Be 0
     }
@@ -107,10 +109,12 @@ Describe 'Get-Catlet name-or-id (integration, read-only)' -Skip:(-not $eryphAvai
 
     BeforeAll { $existing = @(Get-Catlet) }
 
-    It 'returns only catlets whose name matches the pattern' {
+    It 'returns only catlets whose name matches an exact name' {
         if ($existing.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlets present'; return }
         $sample = $existing[0].Name
-        Get-Catlet -Name $sample | ForEach-Object { $_.Name | Should -BeLike $sample }
+        $result = @(Get-Catlet -Name $sample)
+        $result | Should -Not -BeNullOrEmpty
+        $result | ForEach-Object { $_.Name | Should -BeExactly $sample }
     }
 
     It 'resolves a positional GUID to an id lookup' {
@@ -130,6 +134,30 @@ Describe 'Get-Catlet name-or-id (integration, read-only)' -Skip:(-not $eryphAvai
 
     It 'returns nothing for a wildcard with no match' {
         Get-Catlet -Name "zzzz-no-such-catlet-*" | Should -BeNullOrEmpty
+    }
+
+    It '-Config (without -Id) returns YAML config strings, not catlet objects' {
+        if ($existing.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlets present'; return }
+        $config = @(Get-Catlet -Config)
+        $config | Should -Not -BeNullOrEmpty
+        $config[0] | Should -BeOfType [string]
+    }
+}
+
+Describe 'Get-CatletIp name-or-id (integration, read-only)' -Skip:(-not $eryphAvailable) {
+
+    BeforeAll { $withIp = @(Get-Catlet | Where-Object { (Get-CatletIp -Name $_.Name) }) }
+
+    It 'filters by catlet name and returns IPs for that catlet' {
+        if ($withIp.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlet has an IP'; return }
+        $sample = $withIp[0].Name
+        Get-CatletIp -Name $sample | ForEach-Object { $_.Name | Should -BeExactly $sample }
+    }
+
+    It 'resolves a positional GUID to the catlet id' {
+        if ($withIp.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlet has an IP'; return }
+        $one = $withIp[0]
+        Get-CatletIp $one.Id | ForEach-Object { $_.Id | Should -Be $one.Id }
     }
 }
 

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -37,6 +37,8 @@ Describe 'Get-* -Name parameter surface (no server required)' {
         @{ Cmd = 'Get-CatletSpecification' }
         @{ Cmd = 'Get-CatletGene' }
         @{ Cmd = 'Get-CatletIp' }
+        @{ Cmd = 'Get-VNetwork' }
+        @{ Cmd = 'Get-CatletDisk' }
     ) {
         $p = (Get-Command $Cmd).Parameters['Name']
         $p | Should -Not -BeNullOrEmpty
@@ -50,12 +52,23 @@ Describe 'Get-* -Name parameter surface (no server required)' {
         @{ Cmd = 'Get-CatletSpecification' }
         @{ Cmd = 'Get-CatletGene' }
         @{ Cmd = 'Get-CatletIp' }
+        @{ Cmd = 'Get-VNetwork' }
+        @{ Cmd = 'Get-CatletDisk' }
     ) {
         (Get-Command $Cmd).Parameters['Name'].ParameterSets['list'].Position | Should -Be 0
     }
 
     It "Get-CatletGene exposes an -Architecture filter in the 'list' set" {
         $p = (Get-Command Get-CatletGene).Parameters['Architecture']
+        $p | Should -Not -BeNullOrEmpty
+        $p.ParameterSets.Keys | Should -Contain 'list'
+    }
+
+    It "<Cmd> exposes an -Environment filter in the 'list' set" -ForEach @(
+        @{ Cmd = 'Get-VNetwork' }
+        @{ Cmd = 'Get-CatletDisk' }
+    ) {
+        $p = (Get-Command $Cmd).Parameters['Environment']
         $p | Should -Not -BeNullOrEmpty
         $p.ParameterSets.Keys | Should -Contain 'list'
     }
@@ -205,6 +218,52 @@ Describe 'Action cmdlets name resolution (integration, non-destructive)' -Skip:(
 
     It 'Remove-Catlet with a non-matching wildcard does nothing and does not error' {
         { Remove-Catlet -Name 'zzzz-no-such-catlet-*' -Force -ErrorAction Stop } | Should -Not -Throw
+    }
+}
+
+Describe 'Get-VNetwork name-or-id / -Environment (integration, read-only)' -Skip:(-not $eryphAvailable) {
+
+    BeforeAll { $networks = @(Get-VNetwork) }
+
+    It 'filters networks by name' {
+        if ($networks.Count -eq 0) { Set-ItResult -Skipped -Because 'no networks present'; return }
+        $sample = $networks[0].Name
+        Get-VNetwork -Name $sample | ForEach-Object { $_.Name | Should -BeExactly $sample }
+    }
+
+    It 'filters networks by environment' {
+        if ($networks.Count -eq 0) { Set-ItResult -Skipped -Because 'no networks present'; return }
+        $environment = $networks[0].Environment
+        Get-VNetwork -Environment $environment | ForEach-Object { $_.Environment | Should -Be $environment }
+    }
+
+    It 'resolves a positional GUID to an id lookup' {
+        if ($networks.Count -eq 0) { Set-ItResult -Skipped -Because 'no networks present'; return }
+        $one = $networks[0]
+        (Get-VNetwork $one.Id).Id | Should -Be $one.Id
+    }
+}
+
+Describe 'Get-CatletDisk name-or-id / -Environment (integration, read-only)' -Skip:(-not $eryphAvailable) {
+
+    BeforeAll { $disks = @(Get-CatletDisk) }
+
+    It 'filters disks by name' {
+        if ($disks.Count -eq 0) { Set-ItResult -Skipped -Because 'no disks present'; return }
+        $sample = $disks[0].Name
+        Get-CatletDisk -Name $sample | ForEach-Object { $_.Name | Should -BeExactly $sample }
+    }
+
+    It 'filters disks by environment' {
+        if ($disks.Count -eq 0) { Set-ItResult -Skipped -Because 'no disks present'; return }
+        $environment = $disks[0].Environment
+        Get-CatletDisk -Environment $environment | ForEach-Object { $_.Environment | Should -Be $environment }
+    }
+
+    It 'resolves a positional GUID to an id lookup' {
+        if ($disks.Count -eq 0) { Set-ItResult -Skipped -Because 'no disks present'; return }
+        $one = $disks[0]
+        (Get-CatletDisk $one.Id).Id | Should -Be $one.Id
     }
 }
 

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -1,0 +1,123 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+    Pester tests for name-based lookup (issue #69).
+
+    Two layers:
+      * "parameter surface" tests need no server and run anywhere (CI-safe).
+      * "integration" tests exercise the real cmdlet -> HTTP -> filter path against
+        a reachable eryph. They are skipped automatically when no eryph is available.
+
+    The module is imported and the eryph connection is probed during Pester's
+    discovery phase so that -Skip can react to it. Run via Invoke-PesterTests.ps1,
+    which builds the module first.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+# --- Discovery-time setup: import the freshly built module and probe for eryph ---
+$manifest = Get-ChildItem -Path (Join-Path $PSScriptRoot '..' '..' 'src/Eryph.ComputeClient.Commands/bin') `
+    -Recurse -Filter 'Eryph.ComputeClient.psd1' -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $manifest) {
+    throw "Built module not found. Build the Commands project first (Invoke-PesterTests.ps1 -Build)."
+}
+Import-Module $manifest.FullName -Force
+
+$eryphAvailable = $false
+try { $null = Get-EryphProject -ErrorAction Stop; $eryphAvailable = $true } catch { }
+
+Describe 'Get-* -Name parameter surface (no server required)' {
+
+    It "<Cmd> exposes a string -Name in the 'list' parameter set" -ForEach @(
+        @{ Cmd = 'Get-Catlet' }
+        @{ Cmd = 'Get-EryphProject' }
+        @{ Cmd = 'Get-CatletSpecification' }
+        @{ Cmd = 'Get-CatletGene' }
+    ) {
+        $p = (Get-Command $Cmd).Parameters['Name']
+        $p | Should -Not -BeNullOrEmpty
+        $p.ParameterType | Should -Be ([string])
+        $p.ParameterSets.Keys | Should -Contain 'list'
+    }
+
+    It '-Name on Get-Catlet is not positional (must not clash with -Id)' {
+        (Get-Command Get-Catlet).Parameters['Name'].ParameterSets['list'].Position |
+            Should -BeLessThan 0
+    }
+
+    It "Get-CatletGene exposes an -Architecture filter in the 'list' set" {
+        $p = (Get-Command Get-CatletGene).Parameters['Architecture']
+        $p | Should -Not -BeNullOrEmpty
+        $p.ParameterSets.Keys | Should -Contain 'list'
+    }
+}
+
+Describe 'Get-EryphProject -Name (integration)' -Skip:(-not $eryphAvailable) {
+
+    BeforeAll {
+        # Project names are limited to 20 chars, so keep the prefix short.
+        $prefix = "pst$([guid]::NewGuid().ToString('N').Substring(0,6))"  # 9 chars
+        $names  = "$prefix-a", "$prefix-b", "$prefix-c"
+        foreach ($n in $names) { $null = New-EryphProject -Name $n }
+    }
+
+    AfterAll {
+        foreach ($n in $names) {
+            $p = Get-EryphProject -Name $n -ErrorAction SilentlyContinue
+            if ($p) { Remove-EryphProject -Id $p.Id -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'matches an exact name' {
+        (Get-EryphProject -Name "$prefix-a").Name | Should -Be "$prefix-a"
+    }
+
+    It 'matches a wildcard pattern' {
+        (Get-EryphProject -Name "$prefix-*" | Measure-Object).Count | Should -Be 3
+    }
+
+    It 'matches case-insensitively' {
+        (Get-EryphProject -Name "$prefix-A").Name | Should -Be "$prefix-a"
+    }
+
+    It 'returns nothing when no project matches' {
+        Get-EryphProject -Name "$prefix-z" | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-Catlet -Name (integration, read-only)' -Skip:(-not $eryphAvailable) {
+
+    BeforeAll { $existing = @(Get-Catlet) }
+
+    It 'returns only catlets whose name matches the pattern' {
+        if ($existing.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlets present'; return }
+        $sample = $existing[0].Name
+        Get-Catlet -Name $sample | ForEach-Object { $_.Name | Should -BeLike $sample }
+    }
+
+    It "wildcard '*' returns every catlet" {
+        if ($existing.Count -eq 0) { Set-ItResult -Skipped -Because 'no catlets present'; return }
+        (Get-Catlet -Name '*' | Measure-Object).Count | Should -Be $existing.Count
+    }
+
+    It 'returns nothing for a non-existent name' {
+        Get-Catlet -Name "zzz-$([guid]::NewGuid().ToString('N'))" | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-CatletGene -Name / -Architecture (integration, read-only)' -Skip:(-not $eryphAvailable) {
+
+    BeforeAll { $genes = @(Get-CatletGene) }
+
+    It 'filters genes by name pattern' {
+        if ($genes.Count -eq 0) { Set-ItResult -Skipped -Because 'no genes present'; return }
+        $sample = $genes[0].Name
+        Get-CatletGene -Name $sample | ForEach-Object { $_.Name | Should -BeLike $sample }
+    }
+
+    It 'filters genes by architecture' {
+        if ($genes.Count -eq 0) { Set-ItResult -Skipped -Because 'no genes present'; return }
+        $arch = $genes[0].Architecture
+        Get-CatletGene -Architecture $arch | ForEach-Object { $_.Architecture | Should -Be $arch }
+    }
+}

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -101,6 +101,18 @@ Describe 'Action cmdlets accept name-or-id (parameter surface)' {
         $positions = (Get-Command $Cmd).Parameters['Id'].ParameterSets.Values.Position
         $positions | Should -Contain 0
     }
+
+    It "<Cmd> exposes a -ProjectName parameter to scope name resolution" -ForEach @(
+        @{ Cmd = 'Start-Catlet' }
+        @{ Cmd = 'Stop-Catlet' }
+        @{ Cmd = 'Remove-Catlet' }
+        @{ Cmd = 'Update-Catlet' }
+        @{ Cmd = 'Remove-CatletDisk' }
+        @{ Cmd = 'Remove-CatletSpecification' }
+        @{ Cmd = 'Update-CatletSpecification' }
+    ) {
+        (Get-Command $Cmd).Parameters['ProjectName'] | Should -Not -BeNullOrEmpty
+    }
 }
 
 Describe 'Get-EryphProject name-or-id (integration)' -Skip:(-not $eryphAvailable) {
@@ -212,12 +224,26 @@ Describe 'Get-CatletIp name-or-id (integration, read-only)' -Skip:(-not $eryphAv
 
 Describe 'Action cmdlets name resolution (integration, non-destructive)' -Skip:(-not $eryphAvailable) {
 
-    It 'Start-Catlet errors on a non-existent exact name (nothing is started)' {
-        { Start-Catlet -Name "zzz-$([guid]::NewGuid().ToString('N'))" -ErrorAction Stop } | Should -Throw
+    It 'requires -ProjectName when the target is given by name (no cross-project fan-out)' {
+        { Start-Catlet -Name 'some-catlet' -ErrorAction Stop } |
+            Should -Throw -ExpectedMessage '*ProjectName is required*'
     }
 
-    It 'Remove-Catlet with a non-matching wildcard does nothing and does not error' {
-        { Remove-Catlet -Name 'zzzz-no-such-catlet-*' -Force -ErrorAction Stop } | Should -Not -Throw
+    It 'does not require -ProjectName when the target is given by id' {
+        # A random GUID is treated as an id; it should fail with not-found, NOT with the
+        # ProjectName-required error.
+        { Start-Catlet -Id ([guid]::NewGuid().ToString()) -ErrorAction Stop } |
+            Should -Throw -ExpectedMessage '*Cannot find*'
+    }
+
+    It 'Start-Catlet errors on a non-existent exact name within a project (nothing is started)' {
+        { Start-Catlet -Name "zzz-$([guid]::NewGuid().ToString('N'))" -ProjectName 'default' -ErrorAction Stop } |
+            Should -Throw
+    }
+
+    It 'Remove-Catlet with a non-matching wildcard in a project does nothing and does not error' {
+        { Remove-Catlet -Name 'zzzz-no-such-catlet-*' -ProjectName 'default' -Force -ErrorAction Stop } |
+            Should -Not -Throw
     }
 }
 

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -15,11 +15,14 @@
 $ErrorActionPreference = 'Stop'
 
 # --- Discovery-time setup: import the freshly built module and probe for eryph ---
-$manifest = Get-ChildItem -Path (Join-Path $PSScriptRoot '..' '..' 'src/Eryph.ComputeClient.Commands/bin') `
-    -Recurse -Filter 'Eryph.ComputeClient.psd1' -ErrorAction SilentlyContinue |
+# Scope the search to the build configuration the runner selected (default Debug)
+# so we import the matching build rather than just the newest one on disk.
+$configuration = if ($env:ERYPH_TEST_CONFIGURATION) { $env:ERYPH_TEST_CONFIGURATION } else { 'Debug' }
+$binDir = Join-Path $PSScriptRoot '..' '..' "src/Eryph.ComputeClient.Commands/bin/$configuration"
+$manifest = Get-ChildItem -Path $binDir -Recurse -Filter 'Eryph.ComputeClient.psd1' -ErrorAction SilentlyContinue |
     Sort-Object LastWriteTime -Descending | Select-Object -First 1
 if (-not $manifest) {
-    throw "Built module not found. Build the Commands project first (Invoke-PesterTests.ps1 -Build)."
+    throw "Built module not found under '$binDir'. Build the Commands project first (Invoke-PesterTests.ps1 -Build)."
 }
 Import-Module $manifest.FullName -Force
 
@@ -188,6 +191,10 @@ Describe 'Get-CatletIp name-or-id (integration, read-only)' -Skip:(-not $eryphAv
         $one = $withIp[0]
         Get-CatletIp $one.Id | ForEach-Object { $_.Id | Should -Be $one.Id }
     }
+
+    It 'returns nothing for a catlet name that matches nothing' {
+        Get-CatletIp -Name 'zzzz-no-such-catlet-*' | Should -BeNullOrEmpty
+    }
 }
 
 Describe 'Action cmdlets name resolution (integration, non-destructive)' -Skip:(-not $eryphAvailable) {
@@ -215,6 +222,15 @@ Describe 'Get-CatletGene -Name / -Architecture (integration, read-only)' -Skip:(
         if ($genes.Count -eq 0) { Set-ItResult -Skipped -Because 'no genes present'; return }
         $arch = $genes[0].Architecture
         Get-CatletGene -Architecture $arch | ForEach-Object { $_.Architecture | Should -Be $arch }
+    }
+
+    It 'filters genes by name and architecture together' {
+        if ($genes.Count -eq 0) { Set-ItResult -Skipped -Because 'no genes present'; return }
+        $g = $genes[0]
+        Get-CatletGene -Name $g.Name -Architecture $g.Architecture | ForEach-Object {
+            $_.Name | Should -BeLike $g.Name
+            $_.Architecture | Should -Be $g.Architecture
+        }
     }
 
     It 'resolves a positional GUID to a gene record (GeneWithUsage)' {


### PR DESCRIPTION
Closes #69.

Eryph has no server-side search, so name resolution is done client-side: list within scope, then filter by a PowerShell wildcard pattern (case-insensitive; a pattern without wildcard characters matches exactly).

`-Name` is a **positional** parameter on the list cmdlets (Get-EryphProject, Get-Catlet, Get-CatletSpecification, Get-CatletGene, Get-CatletIp) and auto-detects ids: a value that parses as a GUID with no wildcards is looked up by id, otherwise it is treated as a name pattern. Resource ids are always GUIDs and names are short restricted strings, so they can't collide — this keeps `Get-Catlet <guid>` working while enabling `Get-Catlet web*`. `Get-CatletGene` additionally takes an optional `-Architecture` filter.

Miss semantics follow Get-Process/Get-Service: an exact identifier (id or literal name) that matches nothing raises a non-terminating not-found error, while a wildcard pattern returns nothing. Id 404s are wrapped into the same friendly error. `-Id` remains available (explicit + pipeline).

Adds a Pester test project under `test/pester/`: server-less parameter-surface tests plus integration tests that run against a reachable eryph and skip otherwise.