### PR TITLE
Reduce progress flickering during operations (#78)

### DIFF
--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -430,123 +430,124 @@ namespace Eryph.ComputeClient.Commands
             var timeStamp = DateTime.Parse("2018-01-01", CultureInfo.InvariantCulture);
 
 
-            var processedLogIds = new List<string>();
-            var activityCounter = -1;
-            var activityIds = new Dictionary<string, int> { { operation.Id, activityCounter++ } };
+            var processedLogIds = new HashSet<string>();
 
-            var completedActivities = new List<int>();
+            // The operation is shown as a single, stable master progress bar. It
+            // carries no percentage: the number of tasks is only known at runtime and
+            // most tasks never report progress, so any overall total would be
+            // misleading. Only tasks that actually report progress get a child bar,
+            // and each child bar is removed again as soon as its task stops reporting
+            // progress - the set of progress-bearing tasks changes constantly (e.g.
+            // parallel downloads/extractions), so keeping finished ones would quickly
+            // fill the screen. A stable master plus few, real child bars is what
+            // avoids the flickering described in #78.
+            const int operationActivityId = 0;
+            var taskActivityIds = new Dictionary<string, int>();
+            var nextTaskActivityId = 1;
+            var childRecords = new Dictionary<int, ProgressRecord>();
+            var lastWrittenSignatures = new Dictionary<int, string>();
+
+            void WriteProgressIfChanged(ProgressRecord record)
+            {
+                var signature = GetProgressSignature(record);
+                if (lastWrittenSignatures.TryGetValue(record.ActivityId, out var previous)
+                    && previous == signature)
+                    return;
+
+                lastWrittenSignatures[record.ActivityId] = signature;
+                WriteProgress(record);
+            }
 
             var operationsClient = Factory.CreateOperationsClient();
             var currentOperation = operation;
+            ProgressRecord masterRecord = null;
             while (!Stopping)
             {
                 Task.Delay(1000).GetAwaiter().GetResult();
 
                 currentOperation = operationsClient.Get(operation.Id, timeStamp, expand: "logs,tasks").Value;
 
-                foreach (var operationTask in currentOperation.Tasks)
+                var latestLog = currentOperation.LogEntries
+                    .OrderByDescending(x => x.Timestamp)
+                    .FirstOrDefault();
+
+                // The master status text reflects the current phase: the task the
+                // most recent log entry belongs to, falling back to the operation
+                // status when there is no usable task name.
+                var currentPhase = currentOperation.Status.ToString();
+                if (string.IsNullOrWhiteSpace(currentPhase))
+                    currentPhase = "Running"; // ProgressRecord requires a non-empty status description
+                if (latestLog != null)
                 {
-                    if (!activityIds.ContainsKey(operationTask.Id))
-                        activityIds.Add(operationTask.Id, activityCounter++);
+                    var logTask = currentOperation.Tasks.FirstOrDefault(x => x.Id == latestLog.TaskId);
+                    var logTaskName = logTask != null ? GetTaskDisplayName(logTask, operation.Id) : null;
+                    if (!string.IsNullOrWhiteSpace(logTaskName))
+                        currentPhase = logTaskName;
                 }
 
-                var activities = new Dictionary<string,ProgressRecord>();
-                foreach (var operationTask in currentOperation.Tasks)
+                var primaryTask = currentOperation.Tasks
+                    .Where(x => x.ParentTaskId == operation.Id)
+                    .OrderBy(x => x.Id)
+                    .FirstOrDefault();
+                var operationName = primaryTask != null
+                    ? GetTaskDisplayName(primaryTask, operation.Id)
+                    : null;
+                if (string.IsNullOrWhiteSpace(operationName))
+                    operationName = "Operation";
+
+                masterRecord = new ProgressRecord(operationActivityId,
+                    $"{operationName} (Operation: {operation.Id})", currentPhase)
                 {
-                    var displayName = operationTask.DisplayName;
-                    if(string.IsNullOrWhiteSpace(displayName))
+                    PercentComplete = -1,
+                    RecordType = ProgressRecordType.Processing,
+                    CurrentOperation = latestLog?.Message,
+                };
+                WriteProgressIfChanged(masterRecord);
+
+                // Child bars are shown only for tasks that are currently running and
+                // report a progress value.
+                var activeChildIds = new HashSet<int>();
+                foreach (var operationTask in currentOperation.Tasks
+                             .Where(x => x.Status == OperationTaskStatus.Running && x.Progress > 0))
+                {
+                    if (!taskActivityIds.TryGetValue(operationTask.Id, out var activityId))
                     {
-                        if (operationTask.ParentTaskId == operation.Id)
-                        {
-                            displayName = operationTask.Name;
-                            if(displayName.EndsWith("Command"))
-                                // ReSharper disable once ReplaceSubstringWithRangeIndexer
-                                displayName = displayName.Substring(0, displayName.Length - 7);
-                        }
+                        activityId = nextTaskActivityId++;
+                        taskActivityIds[operationTask.Id] = activityId;
                     }
 
-                    if (!string.IsNullOrWhiteSpace(displayName))
+                    var taskName = GetTaskDisplayName(operationTask, operation.Id);
+                    if (string.IsNullOrWhiteSpace(taskName))
+                        taskName = "Task";
+
+                    var progressRecord = new ProgressRecord(activityId, taskName, $"{operationTask.Progress}%")
                     {
-                        var activityName = operationTask.ParentTaskId == operation.Id
-                            ? $"{displayName} (Operation: {operation.Id})"
-                            : $"{displayName} (Task: {operationTask.Id})";
+                        PercentComplete = operationTask.Progress,
+                        ParentActivityId = operationActivityId,
+                        RecordType = ProgressRecordType.Processing,
+                    };
 
-                        var progressRecord = new ProgressRecord(activityIds[operationTask.Id], activityName,
-                            operationTask.Status.ToString())
-                        {
-                            PercentComplete = operationTask.Status == OperationTaskStatus.Completed
-                                ? 100
-                                : operationTask.Progress,
-                            ParentActivityId = !string.IsNullOrWhiteSpace(operationTask.ParentTaskId)
-                                ? activityIds[operationTask.ParentTaskId]
-                                : 0,
-                            RecordType = operationTask.Status == OperationTaskStatus.Completed
-                                ? ProgressRecordType.Completed
-                                : ProgressRecordType.Processing,
-                        };
-
-                        if (progressRecord.PercentComplete == 0)
-                            progressRecord.PercentComplete = -1;
-
-
-                        var lastTaskLogEntry = currentOperation.LogEntries.Where(x => x.TaskId == operationTask.Id)
-                            .OrderByDescending(x => x.Timestamp)
-                            .FirstOrDefault();
-
-                        if (lastTaskLogEntry != null)
-                            progressRecord.CurrentOperation = lastTaskLogEntry.Message;
-
-                        activities.Add(operationTask.Id,progressRecord);
-                    }
-                }
-
-                // second pass for tasks without display name - to show them as operation of parent task
-                foreach (var operationTask in currentOperation.Tasks.Where(x => x.ParentTaskId != operation.Id))
-                {
-                    var displayName = operationTask.DisplayName;
-                    if (!string.IsNullOrWhiteSpace(displayName))
-                        continue;
-
-                    var lastTaskLogEntry = currentOperation.LogEntries.Where(x => x.TaskId == operationTask.Id)
+                    var lastTaskLogEntry = currentOperation.LogEntries
+                        .Where(x => x.TaskId == operationTask.Id)
                         .OrderByDescending(x => x.Timestamp)
                         .FirstOrDefault();
+                    if (lastTaskLogEntry != null)
+                        progressRecord.CurrentOperation = lastTaskLogEntry.Message;
 
-                    if (lastTaskLogEntry == null) continue; // no log, so no need to update parent
-
-                    var parentId = operationTask.ParentTaskId;
-                    while (parentId!= null)
-                    {
-                        var parentTask = currentOperation.Tasks.FirstOrDefault(x => x.Id == parentId);
-                        if(parentTask == null)
-                            break;
-                        
-                        parentId = parentTask.ParentTaskId;
-
-                        if (!activities.TryGetValue(parentTask.Id, out var activity)) continue;
-                        activity.CurrentOperation = lastTaskLogEntry.Message;
-                        break;
-
-                    }
-
+                    childRecords[activityId] = progressRecord;
+                    activeChildIds.Add(activityId);
+                    WriteProgressIfChanged(progressRecord);
                 }
 
-                foreach (var progressRecord in activities.Values.OrderBy(x=>x.ActivityId))
+                // Remove child bars whose task is no longer running with progress.
+                foreach (var staleId in childRecords.Keys.Except(activeChildIds).ToList())
                 {
-                    if(completedActivities.Contains(progressRecord.ActivityId))
-                        continue;
+                    var staleRecord = childRecords[staleId];
+                    staleRecord.RecordType = ProgressRecordType.Completed;
+                    WriteProgress(staleRecord);
 
-                    //looking for running child - in that case keep parent status to running
-                    var runningChild = activities.Any(x =>
-                        x.Value.ParentActivityId == progressRecord.ActivityId &&
-                        progressRecord.RecordType == ProgressRecordType.Processing);
-
-                    if(runningChild)
-                        progressRecord.RecordType = ProgressRecordType.Processing;
-
-                    WriteProgress(progressRecord);
-
-                    if (progressRecord.RecordType == ProgressRecordType.Completed)
-                        completedActivities.Add(progressRecord.ActivityId);
+                    childRecords.Remove(staleId);
+                    lastWrittenSignatures.Remove(staleId);
                 }
 
                 foreach (var logEntry in currentOperation.LogEntries)
@@ -572,10 +573,53 @@ namespace Eryph.ComputeClient.Commands
                         break;
                 }
 
+                // The operation reached a terminal state. Complete the child bars
+                // first, then the master, so PowerShell clears them cleanly.
+                foreach (var record in childRecords.Values)
+                {
+                    record.RecordType = ProgressRecordType.Completed;
+                    WriteProgress(record);
+                }
+
+                if (masterRecord != null)
+                {
+                    masterRecord.RecordType = ProgressRecordType.Completed;
+                    WriteProgress(masterRecord);
+                }
+
                 break;
             }
 
             return currentOperation;
         }
+
+        private static string GetTaskDisplayName(OperationTask task, string operationId)
+        {
+            var displayName = task.DisplayName;
+            if (string.IsNullOrWhiteSpace(displayName) && task.ParentTaskId == operationId)
+            {
+                displayName = task.Name;
+                if (!string.IsNullOrWhiteSpace(displayName) && displayName.EndsWith("Command"))
+                    // ReSharper disable once ReplaceSubstringWithRangeIndexer
+                    displayName = displayName.Substring(0, displayName.Length - 7);
+            }
+
+            return displayName;
+        }
+
+        // Field separator for progress signatures: a control character that cannot
+        // occur in user-visible progress text, so values containing spaces can never
+        // collide into the same signature and suppress a needed update.
+        private static readonly string ProgressFieldSeparator = ((char)0x1f).ToString();
+
+        private static string GetProgressSignature(ProgressRecord record) =>
+            string.Join(ProgressFieldSeparator,
+                record.ActivityId.ToString(CultureInfo.InvariantCulture),
+                record.ParentActivityId.ToString(CultureInfo.InvariantCulture),
+                record.Activity,
+                record.StatusDescription,
+                record.CurrentOperation,
+                record.PercentComplete.ToString(CultureInfo.InvariantCulture),
+                record.RecordType.ToString());
     }
 }

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -466,6 +466,12 @@ namespace Eryph.ComputeClient.Commands
             // quiet polls keep showing them instead of resetting the master bar.
             string lastPhase = null;
             string lastMessage = null;
+            // Detect the progress view mode once; users do not change it mid-operation.
+            // In Minimal view (PS7 default) only one line is shown for all activities,
+            // so the master must carry the rich log message. In Classic view the master
+            // and child render as separate stacked records, so we keep the master
+            // concise when a child is already showing the detail.
+            var isClassicProgressView = IsClassicProgressView();
             while (!Stopping)
             {
                 Task.Delay(1000).GetAwaiter().GetResult();
@@ -504,19 +510,21 @@ namespace Eryph.ComputeClient.Commands
                 }
 
                 // Master status text:
-                // - If any child bar is active, IT carries the message + percent +
-                //   bar for the current task. The master then only needs the phase
-                //   name; using the full message here would duplicate the child's
-                //   CurrentOperation line in classic view.
-                // - Otherwise (no children -> short config steps with no progress
-                //   value) the master itself is the only thing on screen, so it
-                //   carries the latest log message as narration.
-                // Fall back to the climbed phase, then to the operation status.
+                // - Minimal view (PS7 default): only one line is shown for the whole
+                //   progress region, so the master MUST carry the rich log message -
+                //   otherwise the user sees nothing informative during long phases.
+                // - Classic view, child bar active: the child renders its own Activity
+                //   and CurrentOperation lines and carries the message detail. Using
+                //   the full message on the master too would duplicate the child's
+                //   CurrentOperation line. Use the concise climbed phase instead.
+                // - Classic view, no child active: master is the only thing on screen
+                //   for these short config steps, so it carries the log message.
+                // Falls back to the climbed phase, then to the operation status.
                 var hasActiveChild = currentOperation.Tasks
                     .Any(x => x.Status == OperationTaskStatus.Running && x.Progress > 0);
 
                 string statusText;
-                if (hasActiveChild && !string.IsNullOrWhiteSpace(lastPhase))
+                if (isClassicProgressView && hasActiveChild && !string.IsNullOrWhiteSpace(lastPhase))
                 {
                     statusText = lastPhase;
                 }
@@ -639,6 +647,32 @@ namespace Eryph.ComputeClient.Commands
             }
 
             return currentOperation;
+        }
+
+        // PowerShell 7+ exposes the progress view mode via $PSStyle.Progress.View
+        // ('Classic' or 'Minimal'). PowerShell 5.1 has no PSStyle and only renders
+        // classic-style. Reflection avoids a hard reference to PS7-only types.
+        // Returns true for Classic / PS5.1, false for Minimal.
+        private bool IsClassicProgressView()
+        {
+            try
+            {
+                var psStyle = GetVariableValue("PSStyle");
+                if (psStyle == null)
+                    return true;
+
+                var progress = psStyle.GetType().GetProperty("Progress")?.GetValue(psStyle);
+                if (progress == null)
+                    return true;
+
+                var view = progress.GetType().GetProperty("View")?.GetValue(progress);
+                return view == null
+                       || string.Equals(view.ToString(), "Classic", StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return true;
+            }
         }
 
         private static string GetTaskDisplayName(OperationTask task, string operationId)

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -483,10 +483,24 @@ namespace Eryph.ComputeClient.Commands
                 if (latestLog != null)
                 {
                     lastMessage = latestLog.Message;
+                    // Log entries usually come from deep sub-tasks that carry no
+                    // DisplayName themselves. Walk up the parent chain to find the
+                    // nearest task with a usable display name and use that as the
+                    // current phase. Without this walk the master phase rarely gets
+                    // updated and stays stuck on the operation status (see #78).
                     var logTask = currentOperation.Tasks.FirstOrDefault(x => x.Id == latestLog.TaskId);
-                    var logTaskName = logTask != null ? GetTaskDisplayName(logTask, operation.Id) : null;
-                    if (!string.IsNullOrWhiteSpace(logTaskName))
-                        lastPhase = logTaskName;
+                    while (logTask != null)
+                    {
+                        var name = GetTaskDisplayName(logTask, operation.Id);
+                        if (!string.IsNullOrWhiteSpace(name))
+                        {
+                            lastPhase = name;
+                            break;
+                        }
+                        if (string.IsNullOrWhiteSpace(logTask.ParentTaskId))
+                            break;
+                        logTask = currentOperation.Tasks.FirstOrDefault(x => x.Id == logTask.ParentTaskId);
+                    }
                 }
 
                 // Fall back to the operation status until a task name is known.

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -461,6 +461,11 @@ namespace Eryph.ComputeClient.Commands
             var operationsClient = Factory.CreateOperationsClient();
             var currentOperation = operation;
             ProgressRecord masterRecord = null;
+            // Logs are fetched incrementally (the timeStamp advances each poll), so a
+            // poll without new logs returns none. Remember the last phase/message so
+            // quiet polls keep showing them instead of resetting the master bar.
+            string lastPhase = null;
+            string lastMessage = null;
             while (!Stopping)
             {
                 Task.Delay(1000).GetAwaiter().GetResult();
@@ -472,18 +477,24 @@ namespace Eryph.ComputeClient.Commands
                     .FirstOrDefault();
 
                 // The master status text reflects the current phase: the task the
-                // most recent log entry belongs to, falling back to the operation
-                // status when there is no usable task name.
-                var currentPhase = currentOperation.Status.ToString();
-                if (string.IsNullOrWhiteSpace(currentPhase))
-                    currentPhase = "Running"; // ProgressRecord requires a non-empty status description
+                // most recent log entry belongs to. On polls with new logs, refresh
+                // the remembered phase/message; otherwise keep the previous ones so a
+                // quiet poll does not blank the master bar.
                 if (latestLog != null)
                 {
+                    lastMessage = latestLog.Message;
                     var logTask = currentOperation.Tasks.FirstOrDefault(x => x.Id == latestLog.TaskId);
                     var logTaskName = logTask != null ? GetTaskDisplayName(logTask, operation.Id) : null;
                     if (!string.IsNullOrWhiteSpace(logTaskName))
-                        currentPhase = logTaskName;
+                        lastPhase = logTaskName;
                 }
+
+                // Fall back to the operation status until a task name is known.
+                var currentPhase = !string.IsNullOrWhiteSpace(lastPhase)
+                    ? lastPhase
+                    : currentOperation.Status.ToString();
+                if (string.IsNullOrWhiteSpace(currentPhase))
+                    currentPhase = "Running"; // ProgressRecord requires a non-empty status description
 
                 var primaryTask = currentOperation.Tasks
                     .Where(x => x.ParentTaskId == operation.Id)
@@ -500,7 +511,7 @@ namespace Eryph.ComputeClient.Commands
                 {
                     PercentComplete = -1,
                     RecordType = ProgressRecordType.Processing,
-                    CurrentOperation = latestLog?.Message,
+                    CurrentOperation = lastMessage,
                 };
                 WriteProgressIfChanged(masterRecord);
 

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -495,7 +495,10 @@ namespace Eryph.ComputeClient.Commands
                     // current phase. Without this walk the master phase rarely gets
                     // updated and stays stuck on the operation status (see #78).
                     var logTask = currentOperation.Tasks.FirstOrDefault(x => x.Id == latestLog.TaskId);
-                    while (logTask != null)
+                    // Track visited ids so an unexpected cycle in the task graph
+                    // cannot loop forever.
+                    var visitedTasks = new HashSet<string>(StringComparer.Ordinal);
+                    while (logTask != null && visitedTasks.Add(logTask.Id))
                     {
                         var name = GetTaskDisplayName(logTask, operation.Id);
                         if (!string.IsNullOrWhiteSpace(name))
@@ -606,7 +609,12 @@ namespace Eryph.ComputeClient.Commands
                     lastWrittenSignatures.Remove(staleId);
                 }
 
-                foreach (var logEntry in currentOperation.LogEntries)
+                // Iterate logs in chronological order so timeStamp always advances
+                // to the newest entry in the batch. Otherwise a later poll could
+                // re-request entries that fell between the last-iterated and the
+                // max timestamp of this batch (still deduped by processedLogIds,
+                // but wasted bandwidth).
+                foreach (var logEntry in currentOperation.LogEntries.OrderBy(x => x.Timestamp))
                 {
                     if (processedLogIds.Contains(logEntry.Id))
                         continue;

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -503,17 +503,31 @@ namespace Eryph.ComputeClient.Commands
                     }
                 }
 
-                // The latest log message is the actual narration of what is happening
-                // ("Attaching HD Drive sda...", "Updating cloud-init config drive"
-                // etc.). It exists for every step regardless of whether the owning
-                // task carries a DisplayName, so it is the most reliable source of
-                // updates - prefer it as status text. Fall back to the resolved
-                // phase name, then to the operation status.
-                var statusText = !string.IsNullOrWhiteSpace(lastMessage)
-                    ? lastMessage
-                    : !string.IsNullOrWhiteSpace(lastPhase)
-                        ? lastPhase
-                        : currentOperation.Status.ToString();
+                // Master status text:
+                // - If any child bar is active, IT carries the message + percent +
+                //   bar for the current task. The master then only needs the phase
+                //   name; using the full message here would duplicate the child's
+                //   CurrentOperation line in classic view.
+                // - Otherwise (no children -> short config steps with no progress
+                //   value) the master itself is the only thing on screen, so it
+                //   carries the latest log message as narration.
+                // Fall back to the climbed phase, then to the operation status.
+                var hasActiveChild = currentOperation.Tasks
+                    .Any(x => x.Status == OperationTaskStatus.Running && x.Progress > 0);
+
+                string statusText;
+                if (hasActiveChild && !string.IsNullOrWhiteSpace(lastPhase))
+                {
+                    statusText = lastPhase;
+                }
+                else
+                {
+                    statusText = !string.IsNullOrWhiteSpace(lastMessage)
+                        ? lastMessage
+                        : !string.IsNullOrWhiteSpace(lastPhase)
+                            ? lastPhase
+                            : currentOperation.Status.ToString();
+                }
                 if (string.IsNullOrWhiteSpace(statusText))
                     statusText = "Running"; // ProgressRecord requires a non-empty status description
 
@@ -532,9 +546,9 @@ namespace Eryph.ComputeClient.Commands
                 {
                     PercentComplete = -1,
                     RecordType = ProgressRecordType.Processing,
-                    // Phase name (resolved by climbing the task chain) is shown as
-                    // additional context in hosts that render CurrentOperation.
-                    CurrentOperation = lastPhase,
+                    // No CurrentOperation: in classic view this would render as an
+                    // extra line below the master bar duplicating what an active
+                    // child bar already shows in its own Activity line.
                 };
                 WriteProgressIfChanged(masterRecord);
 

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -503,12 +503,19 @@ namespace Eryph.ComputeClient.Commands
                     }
                 }
 
-                // Fall back to the operation status until a task name is known.
-                var currentPhase = !string.IsNullOrWhiteSpace(lastPhase)
-                    ? lastPhase
-                    : currentOperation.Status.ToString();
-                if (string.IsNullOrWhiteSpace(currentPhase))
-                    currentPhase = "Running"; // ProgressRecord requires a non-empty status description
+                // The latest log message is the actual narration of what is happening
+                // ("Attaching HD Drive sda...", "Updating cloud-init config drive"
+                // etc.). It exists for every step regardless of whether the owning
+                // task carries a DisplayName, so it is the most reliable source of
+                // updates - prefer it as status text. Fall back to the resolved
+                // phase name, then to the operation status.
+                var statusText = !string.IsNullOrWhiteSpace(lastMessage)
+                    ? lastMessage
+                    : !string.IsNullOrWhiteSpace(lastPhase)
+                        ? lastPhase
+                        : currentOperation.Status.ToString();
+                if (string.IsNullOrWhiteSpace(statusText))
+                    statusText = "Running"; // ProgressRecord requires a non-empty status description
 
                 var primaryTask = currentOperation.Tasks
                     .Where(x => x.ParentTaskId == operation.Id)
@@ -521,11 +528,13 @@ namespace Eryph.ComputeClient.Commands
                     operationName = "Operation";
 
                 masterRecord = new ProgressRecord(operationActivityId,
-                    $"{operationName} (Operation: {operation.Id})", currentPhase)
+                    $"{operationName} (Operation: {operation.Id})", statusText)
                 {
                     PercentComplete = -1,
                     RecordType = ProgressRecordType.Processing,
-                    CurrentOperation = lastMessage,
+                    // Phase name (resolved by climbing the task chain) is shown as
+                    // additional context in hosts that render CurrentOperation.
+                    CurrentOperation = lastPhase,
                 };
                 WriteProgressIfChanged(masterRecord);
 


### PR DESCRIPTION
Operation progress was reported as one PowerShell progress activity per task. Since tasks are created at runtime and most are short steps without a progress value, the set of activities churned constantly - bars were added and removed on every poll, forcing the host to redraw the whole progress region (flickering, worst in classic view / Windows Terminal).

This renders a single stable master bar for the operation instead. It carries no overall percentage (the task count is only known at runtime and most tasks report no progress, so any total would be misleading). Only tasks that actually report a progress value get a child bar, and each child bar is removed as soon as its task stops reporting progress, so parallel downloads/extractions don't pile up on screen. Progress records are re-written only when their content actually changed.

Full per-task and log detail remains available on the verbose stream.

Fixes #78.