### PR TITLE
Correct name-lookup contracts for disks and genes

### DIFF
--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletDiskCommand.cs
@@ -35,6 +35,14 @@ public class GetCatletDiskCommand : CatletDiskCmdlet
     [ValidateNotNullOrEmpty]
     public string Environment { get; set; }
 
+    [Parameter(ParameterSetName = "list")]
+    [ValidateNotNullOrEmpty]
+    public string Location { get; set; }
+
+    [Parameter(ParameterSetName = "list")]
+    [ValidateNotNullOrEmpty]
+    public string DataStore { get; set; }
+
     protected override void ProcessRecord()
     {
         if (Id != null)
@@ -52,12 +60,17 @@ public class GetCatletDiskCommand : CatletDiskCmdlet
         if (!TryGetProjectId(ProjectName, out var projectId))
             return;
 
-        // Disk names are unique per project + environment, so allow narrowing by
-        // environment. The environment filter is applied to the listing; an explicit
-        // id (GUID) ignores it.
+        // A disk is identified by Name + Location + DataStore (within a project), so
+        // -Name alone may not be unique. Allow narrowing the listing by -Environment,
+        // -Location and -DataStore (case-insensitive exact match). An explicit id
+        // (GUID) bypasses these filters.
         IEnumerable<VirtualDisk> disks = Factory.CreateVirtualDisksClient().List(projectId: projectId);
         if (!string.IsNullOrWhiteSpace(Environment))
             disks = disks.Where(d => string.Equals(d.Environment, Environment, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(Location))
+            disks = disks.Where(d => string.Equals(d.Location, Location, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(DataStore))
+            disks = disks.Where(d => string.Equals(d.DataStore, DataStore, StringComparison.OrdinalIgnoreCase));
 
         WriteByNameOrId(Name, GetSingleCatletDisk, () => disks, d => d.Name, "catlet disk");
     }

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletDiskCmdlet.cs
@@ -15,12 +15,16 @@ namespace Eryph.ComputeClient.Commands.Catlets;
 [OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
 public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
 {
+    // A disk is identified by Name + Location + DataStore (within a project), so
+    // -Name alone cannot uniquely identify the target of a destructive operation.
+    // Remove-CatletDisk therefore accepts only ids; use Get-CatletDisk (which
+    // supports -Name plus -Environment / -Location / -DataStore filters) to find
+    // the disk first and pipe it in.
     [Parameter(
         Position = 0,
         ValueFromPipeline = true,
         Mandatory = true,
         ValueFromPipelineByPropertyName = true)]
-    [Alias("Name")]
     public string[] Id { get; set; }
 
     /// <summary>
@@ -42,40 +46,28 @@ public class RemoveCatletDiskCmdlet : CatletDiskCmdlet
     [Parameter(ParameterSetName = "NoWait")]
     public SwitchParameter NoWait { get; set; }
 
-    [Parameter]
-    [ValidateNotNullOrEmpty]
-    public string ProjectName { get; set; }
-
-    [Parameter]
-    [ValidateNotNullOrEmpty]
-    public string Environment { get; set; }
-
     private bool _yesToAll;
     private bool _noToAll;
 
     protected override void ProcessRecord()
     {
-        foreach (var nameOrId in Id)
+        foreach (var id in Id)
         {
-            foreach (var virtualDisk in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatletDisk,
-                         projectId => Factory.CreateVirtualDisksClient().List(projectId: projectId)
-                             .Where(d => string.IsNullOrWhiteSpace(Environment)
-                                         || string.Equals(d.Environment, Environment, StringComparison.OrdinalIgnoreCase)),
-                         d => d.Name, "catlet disk", ambiguityHint: "-Environment"))
+            if (Stopping) break;
+
+            if (!TryGetById(id, GetSingleCatletDisk, "catlet disk", out var virtualDisk))
+                continue;
+
+            if (!Force && !ShouldContinue($"Catlet disk '{virtualDisk.Name}' (Id:{virtualDisk.Id}) will be deleted!", "Warning!",
+                    ref _yesToAll, ref _noToAll))
             {
-                if (Stopping) break;
-
-                if (!Force && !ShouldContinue($"Catlet disk '{virtualDisk.Name}' (Id:{virtualDisk.Id}) will be deleted!", "Warning!",
-                        ref _yesToAll, ref _noToAll))
-                {
-                    continue;
-                }
-
-                WaitForOperation(Factory.CreateVirtualDisksClient().Delete(virtualDisk.Id).Value, NoWait, false, virtualDisk.Id);
-
-                if (PassThru)
-                    WriteObject(virtualDisk);
+                continue;
             }
+
+            WaitForOperation(Factory.CreateVirtualDisksClient().Delete(virtualDisk.Id).Value, NoWait, false, virtualDisk.Id);
+
+            if (PassThru)
+                WriteObject(virtualDisk);
         }
     }
 }

--- a/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
+++ b/src/Eryph.ComputeClient.Commands/ComputeCmdLet.cs
@@ -320,7 +320,8 @@ namespace Eryph.ComputeClient.Commands
             IEnumerable<T> items,
             string namePattern,
             Func<T, string> nameSelector,
-            string resourceKind)
+            string resourceKind,
+            string fieldName = "name")
         {
             // Only a null/empty pattern means "no filter" (yield everything). A
             // whitespace-only value is a real (if non-matching) name, not "list all" —
@@ -347,11 +348,13 @@ namespace Eryph.ComputeClient.Commands
                 yield return item;
             }
 
-            // An exact name (no wildcards) that matches nothing is an error, mirroring
+            // An exact value (no wildcards) that matches nothing is an error, mirroring
             // Get-Process/Get-Service. A wildcard pattern simply yields nothing. Do not
             // raise the error when the pipeline was stopped before a match was found.
+            // `fieldName` lets callers that filter by something other than the resource's
+            // `name` property (e.g. a gene's `geneset`) produce a meaningful error.
             if (!Stopping && !matched && pattern is not null && !hasWildcards)
-                WriteError(ResourceNotFound(resourceKind, "name", namePattern));
+                WriteError(ResourceNotFound(resourceKind, fieldName, namePattern));
         }
 
         /// <summary>
@@ -378,10 +381,11 @@ namespace Eryph.ComputeClient.Commands
             string namePattern,
             Func<T, string> nameSelector,
             string resourceKind,
-            Action<T> writeItem = null)
+            Action<T> writeItem = null,
+            string fieldName = "name")
         {
             writeItem ??= item => WriteObject(item);
-            foreach (var item in FilterByName(items, namePattern, nameSelector, resourceKind))
+            foreach (var item in FilterByName(items, namePattern, nameSelector, resourceKind, fieldName))
                 writeItem(item);
         }
 

--- a/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
@@ -21,9 +21,16 @@ public class GetCatletGeneCmdlet : CatletGeneCmdlet
         ValueFromPipelineByPropertyName = true)]
     public string[] Id { get; set; }
 
+    // GeneSet is the natural identifier of a gene (org/set/version reference);
+    // Name is a sub-attribute within a geneset. So the positional filter binds to
+    // GeneSet and Name is offered as a secondary, non-positional refinement.
     [Parameter(
         ParameterSetName = "list",
         Position = 0)]
+    [ValidateNotNullOrEmpty]
+    public string GeneSet { get; set; }
+
+    [Parameter(ParameterSetName = "list")]
     [ValidateNotNullOrEmpty]
     public string Name { get; set; }
 
@@ -47,20 +54,27 @@ public class GetCatletGeneCmdlet : CatletGeneCmdlet
 
         // A positional GUID is a gene record id; look it up directly (returns the
         // richer GeneWithUsage), mirroring -Id.
-        if (IsResourceId(Name))
+        if (IsResourceId(GeneSet))
         {
-            if (TryGetById(Name, GetSingleGene, "gene", out var geneById))
+            if (TryGetById(GeneSet, GetSingleGene, "gene", out var geneById))
                 WriteObject(geneById);
             return;
         }
 
         // Genes list globally and are identified by GeneSet + Name + Architecture.
-        // Architecture is an exact (case-insensitive) filter; Name supports wildcards.
+        // GeneSet supports wildcards (with the standard Get-Process miss-not-found
+        // semantics for an exact pattern); Architecture and Name are case-insensitive
+        // refinement filters.
         IEnumerable<Gene> genes = Factory.CreateGenesClient().List();
         if (!string.IsNullOrWhiteSpace(Architecture))
             genes = genes.Where(gene =>
                 string.Equals(gene.Architecture, Architecture, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(Name))
+        {
+            var namePattern = new WildcardPattern(Name, WildcardOptions.IgnoreCase);
+            genes = genes.Where(gene => gene.Name is not null && namePattern.IsMatch(gene.Name));
+        }
 
-        WriteFilteredByName(genes, Name, gene => gene.Name, "gene");
+        WriteFilteredByName(genes, GeneSet, gene => gene.GeneSet, "gene", fieldName: "geneset");
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Genes/GetCatletGeneCmdlet.cs
@@ -69,7 +69,9 @@ public class GetCatletGeneCmdlet : CatletGeneCmdlet
         if (!string.IsNullOrWhiteSpace(Architecture))
             genes = genes.Where(gene =>
                 string.Equals(gene.Architecture, Architecture, StringComparison.OrdinalIgnoreCase));
-        if (!string.IsNullOrWhiteSpace(Name))
+        // Gate on null/empty (not whitespace) to match FilterByName: a whitespace-only
+        // value is a real (if non-matching) pattern, not "list all".
+        if (!string.IsNullOrEmpty(Name))
         {
             var namePattern = new WildcardPattern(Name, WildcardOptions.IgnoreCase);
             genes = genes.Where(gene => gene.Name is not null && namePattern.IsMatch(gene.Name));

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -50,12 +50,19 @@ Describe 'Get-* -Name parameter surface (no server required)' {
         @{ Cmd = 'Get-Catlet' }
         @{ Cmd = 'Get-EryphProject' }
         @{ Cmd = 'Get-CatletSpecification' }
-        @{ Cmd = 'Get-CatletGene' }
         @{ Cmd = 'Get-CatletIp' }
         @{ Cmd = 'Get-VNetwork' }
         @{ Cmd = 'Get-CatletDisk' }
     ) {
         (Get-Command $Cmd).Parameters['Name'].ParameterSets['list'].Position | Should -Be 0
+    }
+
+    It "Get-CatletGene takes -GeneSet (the natural identifier) as positional parameter 0, with -Name as a secondary non-positional filter" {
+        $params = (Get-Command Get-CatletGene).Parameters
+        $params['GeneSet'].ParameterType                      | Should -Be ([string])
+        $params['GeneSet'].ParameterSets['list'].Position     | Should -Be 0
+        # Name still exists in the 'list' set but is not positional.
+        $params['Name'].ParameterSets['list'].Position        | Should -BeLessThan 0
     }
 
     It "Get-CatletGene exposes an -Architecture filter in the 'list' set" {
@@ -370,11 +377,17 @@ Describe 'Get-CatletDisk filters (integration, read-only)' -Skip:(-not $eryphAva
     }
 }
 
-Describe 'Get-CatletGene -Name / -Architecture (integration, read-only)' -Skip:(-not $eryphAvailable) {
+Describe 'Get-CatletGene filters (integration, read-only)' -Skip:(-not $eryphAvailable) {
 
     BeforeAll { $genes = @(Get-CatletGene) }
 
-    It 'filters genes by name pattern' {
+    It 'filters genes by positional geneset (the natural identifier)' {
+        if ($genes.Count -eq 0) { Set-ItResult -Skipped -Because 'no genes present'; return }
+        $sample = $genes[0].GeneSet
+        Get-CatletGene $sample | ForEach-Object { $_.GeneSet | Should -BeLike $sample }
+    }
+
+    It 'filters genes by -Name as a refinement filter' {
         if ($genes.Count -eq 0) { Set-ItResult -Skipped -Because 'no genes present'; return }
         $sample = $genes[0].Name
         Get-CatletGene -Name $sample | ForEach-Object { $_.Name | Should -BeLike $sample }
@@ -386,11 +399,12 @@ Describe 'Get-CatletGene -Name / -Architecture (integration, read-only)' -Skip:(
         Get-CatletGene -Architecture $arch | ForEach-Object { $_.Architecture | Should -Be $arch }
     }
 
-    It 'filters genes by name and architecture together' {
+    It 'filters genes by geneset, name and architecture together' {
         if ($genes.Count -eq 0) { Set-ItResult -Skipped -Because 'no genes present'; return }
         $g = $genes[0]
-        Get-CatletGene -Name $g.Name -Architecture $g.Architecture | ForEach-Object {
-            $_.Name | Should -BeLike $g.Name
+        Get-CatletGene $g.GeneSet -Name $g.Name -Architecture $g.Architecture | ForEach-Object {
+            $_.GeneSet      | Should -BeLike $g.GeneSet
+            $_.Name         | Should -BeLike $g.Name
             $_.Architecture | Should -Be $g.Architecture
         }
     }

--- a/test/pester/ResourceNameLookup.Tests.ps1
+++ b/test/pester/ResourceNameLookup.Tests.ps1
@@ -73,6 +73,15 @@ Describe 'Get-* -Name parameter surface (no server required)' {
         $p.ParameterSets.Keys | Should -Contain 'list'
     }
 
+    It "Get-CatletDisk exposes a -<Param> filter in the 'list' set (Name+Location+DataStore needed to identify a disk)" -ForEach @(
+        @{ Param = 'Location' }
+        @{ Param = 'DataStore' }
+    ) {
+        $p = (Get-Command Get-CatletDisk).Parameters[$Param]
+        $p | Should -Not -BeNullOrEmpty
+        $p.ParameterSets.Keys | Should -Contain 'list'
+    }
+
     It "<Cmd> exposes an optional -ProjectName filter in the 'list' set" -ForEach @(
         @{ Cmd = 'Get-Catlet' }
         @{ Cmd = 'Get-CatletDisk' }
@@ -93,7 +102,6 @@ Describe 'Action cmdlets accept name-or-id (parameter surface)' {
         @{ Cmd = 'Stop-Catlet' }
         @{ Cmd = 'Remove-Catlet' }
         @{ Cmd = 'Update-Catlet' }
-        @{ Cmd = 'Remove-CatletDisk' }
         @{ Cmd = 'Remove-CatletSpecification' }
         @{ Cmd = 'Update-CatletSpecification' }
         @{ Cmd = 'Remove-EryphProject' }
@@ -119,15 +127,19 @@ Describe 'Action cmdlets accept name-or-id (parameter surface)' {
         @{ Cmd = 'Stop-Catlet' }
         @{ Cmd = 'Remove-Catlet' }
         @{ Cmd = 'Update-Catlet' }
-        @{ Cmd = 'Remove-CatletDisk' }
         @{ Cmd = 'Remove-CatletSpecification' }
         @{ Cmd = 'Update-CatletSpecification' }
     ) {
         (Get-Command $Cmd).Parameters['ProjectName'] | Should -Not -BeNullOrEmpty
     }
 
-    It 'Remove-CatletDisk exposes an -Environment scope (disk names are unique per project + environment)' {
-        (Get-Command Remove-CatletDisk).Parameters['Environment'] | Should -Not -BeNullOrEmpty
+    It 'Remove-CatletDisk is Id-only (Name+Location+DataStore is required to identify a disk; use Get-CatletDisk to resolve)' {
+        $params = (Get-Command Remove-CatletDisk).Parameters
+        # Keeps -Id positional, but offers no name-based lookup and no scope params.
+        $params['Id'].Aliases             | Should -Not -Contain 'Name'
+        $params['ProjectName']            | Should -BeNullOrEmpty
+        $params['Environment']            | Should -BeNullOrEmpty
+        $params['Id'].ParameterSets.Values.Position | Should -Contain 0
     }
 }
 
@@ -314,7 +326,7 @@ Describe 'Get-VNetwork name-or-id / -Environment (integration, read-only)' -Skip
     }
 }
 
-Describe 'Get-CatletDisk name-or-id / -Environment (integration, read-only)' -Skip:(-not $eryphAvailable) {
+Describe 'Get-CatletDisk filters (integration, read-only)' -Skip:(-not $eryphAvailable) {
 
     BeforeAll { $disks = @(Get-CatletDisk) }
 
@@ -330,6 +342,24 @@ Describe 'Get-CatletDisk name-or-id / -Environment (integration, read-only)' -Sk
         $filtered = @(Get-CatletDisk -Environment $environment)
         $filtered | ForEach-Object { $_.Environment | Should -Be $environment }
         $expected = @($disks | Where-Object Environment -EQ $environment).Count
+        $filtered.Count | Should -Be $expected
+    }
+
+    It 'filters disks by location' {
+        if ($disks.Count -eq 0) { Set-ItResult -Skipped -Because 'no disks present'; return }
+        $location = $disks[0].Location
+        $filtered = @(Get-CatletDisk -Location $location)
+        $filtered | ForEach-Object { $_.Location | Should -Be $location }
+        $expected = @($disks | Where-Object Location -EQ $location).Count
+        $filtered.Count | Should -Be $expected
+    }
+
+    It 'filters disks by datastore' {
+        if ($disks.Count -eq 0) { Set-ItResult -Skipped -Because 'no disks present'; return }
+        $datastore = $disks[0].DataStore
+        $filtered = @(Get-CatletDisk -DataStore $datastore)
+        $filtered | ForEach-Object { $_.DataStore | Should -Be $datastore }
+        $expected = @($disks | Where-Object DataStore -EQ $datastore).Count
         $filtered.Count | Should -Be $expected
     }
 


### PR DESCRIPTION
Two follow-ups to PR #113 (`Allow looking up resources by name`) where the name-lookup contract didn't match the actual uniqueness model.

**Disks.** A disk is identified by `Name + Location + DataStore` within a project, not by `Name` alone within a project + environment.

- `Get-CatletDisk` gains `-Location` and `-DataStore` list filters next to the existing `-Environment`, so callers can narrow a listing down to one disk before piping it into an operation.
- `Remove-CatletDisk` drops name lookup entirely - the `Name` alias on `-Id` and the `-ProjectName` / `-Environment` scope parameters are gone, leaving it `-Id`-only. Resolve a disk with `Get-CatletDisk` first, then pipe it in.

**Genes.** The natural identifier of a gene is the geneset reference (`org/set/version`); the gene's `Name` is a sub-attribute within a geneset.

- `Get-CatletGene` positional parameter changes from `-Name` to `-GeneSet`, so `Get-CatletGene dbosoft/almalinux-9` does the obvious thing.
- `-Name` becomes a secondary, non-positional refinement filter. `-Architecture` is unchanged. A positional GUID still short-circuits to an id lookup, as before.

`FilterByName` / `WriteFilteredByName` were extended with an optional `fieldName` parameter so the miss-not-found error reads "Cannot find a gene with the geneset 'X'" instead of "with the name 'X'". Default keeps the existing helpers behaviourally identical for every other caller.

Pester tests under `test/pester/ResourceNameLookup.Tests.ps1` updated to assert the new contracts.