### PR TITLE
Fix CatletSpecificationVersion pipelining and deploy workflow

### DIFF
--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecification.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecification.cs
@@ -15,6 +15,8 @@ namespace Eryph.ComputeClient.Commands.CatletSpecifications;
 [Cmdlet(VerbsCommon.Get, "CatletSpecification", DefaultParameterSetName = "list")]
 [OutputType(typeof(CatletSpecification), ParameterSetName = ["get"])]
 [OutputType(typeof(CatletSpecification), ParameterSetName = ["list"])]
+[OutputType(typeof(string), ParameterSetName = ["get"])]
+[OutputType(typeof(string), ParameterSetName = ["list"])]
 public class GetCatletSpecification : CatletSpecificationCmdlet
 {
     [Parameter(
@@ -35,6 +37,11 @@ public class GetCatletSpecification : CatletSpecificationCmdlet
     [ValidateNotNullOrEmpty]
     public string Name { get; set; }
 
+    // Return the configuration content of each specification's latest version as a
+    // string instead of the specification object (mirrors 'Get-CatletSpecificationVersion -Config').
+    [Parameter]
+    public SwitchParameter Config { get; set; }
+
     protected override void ProcessRecord()
     {
         if (Id is not null)
@@ -43,7 +50,12 @@ public class GetCatletSpecification : CatletSpecificationCmdlet
             {
                 if (Stopping) break;
                 if (TryGetById(id, GetSingleCatletSpecification, "catlet specification", out var specification))
-                    WriteObject(specification);
+                {
+                    if (Config.IsPresent)
+                        WriteSpecificationConfig(specification);
+                    else
+                        WriteObject(specification);
+                }
             }
 
             return;
@@ -52,11 +64,32 @@ public class GetCatletSpecification : CatletSpecificationCmdlet
         if (!TryGetProjectId(ProjectName, out var projectId))
             return;
 
+        Action<CatletSpecification> writeItem = Config.IsPresent ? WriteSpecificationConfig : null;
         WriteByNameOrId(
             Name,
             GetSingleCatletSpecification,
             () => Factory.CreateCatletSpecificationsClient().List(projectId: projectId),
             specification => specification.Name,
-            "catlet specification");
+            "catlet specification",
+            writeItem);
+    }
+
+    // Writes the configuration content of the specification's latest version.
+    private void WriteSpecificationConfig(CatletSpecification specification)
+    {
+        if (specification.Latest is null)
+        {
+            WriteError(new ErrorRecord(
+                new ItemNotFoundException(
+                    $"The catlet specification '{specification.Name}' does not have any versions."),
+                "NoVersions",
+                ErrorCategory.ObjectNotFound,
+                specification));
+            return;
+        }
+
+        var version = Factory.CreateCatletSpecificationsClient()
+            .GetVersion(specification.Id, specification.Latest.Id).Value;
+        WriteObject(version.Configuration.Content);
     }
 }

--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecificationVersion.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecificationVersion.cs
@@ -56,7 +56,7 @@ public class GetCatletSpecificationVersion : CatletSpecificationCmdlet
 
         if (Config.IsPresent)
         {
-            foreach (var versionId in ResolveVersionIds(specificationsClient))
+            foreach (var versionId in ResolveVersionIds())
             {
                 if (Stopping) break;
 
@@ -90,7 +90,7 @@ public class GetCatletSpecificationVersion : CatletSpecificationCmdlet
 
     // The explicit -VersionId values, or the latest version of the specification when
     // none were given.
-    private string[] ResolveVersionIds(CatletSpecificationsClient specificationsClient)
+    private string[] ResolveVersionIds()
     {
         if (VersionId is not null)
             return VersionId;

--- a/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecificationVersion.cs
+++ b/src/Eryph.ComputeClient.Commands/CatletSpecifications/GetCatletSpecificationVersion.cs
@@ -1,50 +1,112 @@
-﻿using System.Management.Automation;
+using System.Management.Automation;
 using Eryph.ComputeClient.Models;
 using JetBrains.Annotations;
 
 namespace Eryph.ComputeClient.Commands.CatletSpecifications;
 
 [PublicAPI]
-[Cmdlet(VerbsCommon.Get, "CatletSpecificationVersion", DefaultParameterSetName = "get")]
-[OutputType(typeof(CatletSpecificationVersion), ParameterSetName = ["get"])]
+[Cmdlet(VerbsCommon.Get, "CatletSpecificationVersion", DefaultParameterSetName = "list")]
 [OutputType(typeof(CatletSpecificationVersionInfo), ParameterSetName = ["list"])]
+[OutputType(typeof(CatletSpecificationVersion), ParameterSetName = ["get"])]
+[OutputType(typeof(string), ParameterSetName = ["getconfig"])]
 public class GetCatletSpecificationVersion : CatletSpecificationCmdlet
 {
-    [Parameter(
-        ParameterSetName = "get",
-        Position = 0,
-        ValueFromPipeline = true,
-        ValueFromPipelineByPropertyName = true)]
-    public string[] Id { get; set; }
-
+    // The id of the parent catlet specification. Aliased to 'Id' and bound from
+    // the pipeline by property name so that 'Get-CatletSpecification | Get-CatletSpecificationVersion'
+    // works: a CatletSpecification exposes its id as 'Id', not 'SpecificationId'.
     [Parameter(
         ParameterSetName = "list",
+        Mandatory = true,
         ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true)]
-    [Parameter(ParameterSetName = "get", Mandatory = true)]
+    [Parameter(
+        ParameterSetName = "get",
+        Mandatory = true,
+        ValueFromPipelineByPropertyName = true)]
+    [Parameter(
+        ParameterSetName = "getconfig",
+        Mandatory = true,
+        ValueFromPipelineByPropertyName = true)]
+    [Alias("Id")]
     [ValidateNotNullOrEmpty]
     public string SpecificationId { get; set; }
 
+    // The version is mandatory when retrieving the full version object, but optional
+    // for -Config: without it, the configuration of the specification's latest version
+    // is returned.
+    [Parameter(
+        ParameterSetName = "get",
+        Position = 0,
+        Mandatory = true)]
+    [Parameter(
+        ParameterSetName = "getconfig",
+        Position = 0)]
+    [Alias("SpecificationVersionId")]
+    [ValidateNotNullOrEmpty]
+    public string[] VersionId { get; set; }
+
+    [Parameter(
+        ParameterSetName = "getconfig",
+        Mandatory = true)]
+    public SwitchParameter Config { get; set; }
+
     protected override void ProcessRecord()
     {
-        if (Id is not null)
+        var specificationsClient = Factory.CreateCatletSpecificationsClient();
+
+        if (Config.IsPresent)
         {
-            var specificationsClient = Factory.CreateCatletSpecificationsClient();
-            foreach (var id in Id)
+            foreach (var versionId in ResolveVersionIds(specificationsClient))
             {
-                WriteObject(specificationsClient.GetVersion(SpecificationId, id).Value);
+                if (Stopping) break;
+
+                var version = specificationsClient.GetVersion(SpecificationId, versionId).Value;
+                WriteObject(version.Configuration.Content);
             }
 
             return;
         }
 
-        var specificationVersions = Factory.CreateCatletSpecificationsClient()
-            .ListVersions(specificationId: SpecificationId);
-        foreach (var specification in specificationVersions)
+        if (VersionId is not null)
+        {
+            foreach (var versionId in VersionId)
+            {
+                if (Stopping) break;
+
+                WriteObject(specificationsClient.GetVersion(SpecificationId, versionId).Value);
+            }
+
+            return;
+        }
+
+        var specificationVersions = specificationsClient.ListVersions(specificationId: SpecificationId);
+        foreach (var specificationVersion in specificationVersions)
         {
             if (Stopping) break;
 
-            WriteObject(specification, true);
+            WriteObject(specificationVersion, true);
         }
+    }
+
+    // The explicit -VersionId values, or the latest version of the specification when
+    // none were given.
+    private string[] ResolveVersionIds(CatletSpecificationsClient specificationsClient)
+    {
+        if (VersionId is not null)
+            return VersionId;
+
+        var specification = GetSingleCatletSpecification(SpecificationId);
+        if (specification.Latest is null)
+        {
+            WriteError(new ErrorRecord(
+                new ItemNotFoundException(
+                    $"The catlet specification '{SpecificationId}' does not have any versions."),
+                "NoVersions",
+                ErrorCategory.ObjectNotFound,
+                SpecificationId));
+            return [];
+        }
+
+        return [specification.Latest.Id];
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/SubmitCatletDeployment.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/SubmitCatletDeployment.cs
@@ -2,13 +2,9 @@
 using System.Collections;
 using System.Linq;
 using System.Management.Automation;
-using System.Net;
-using System.Text.Json;
-using Azure;
 using Eryph.ComputeClient.Models;
 using Eryph.ConfigModel.Json;
 using JetBrains.Annotations;
-using Operation = Eryph.ComputeClient.Models.Operation;
 
 namespace Eryph.ComputeClient.Commands.Catlets;
 
@@ -88,6 +84,29 @@ public class SubmitCatletDeployment : CatletConfigCmdlet
         if (specificationId is null || specificationVersionId is null)
             return;
 
+        // A deployed specification carries the id of the catlet it was deployed as.
+        // The piped specification already tells us; for other inputs we ask the server.
+        // Detecting this up front lets us point at -Redeploy instead of failing the
+        // deployment with a backend conflict.
+        if (!Redeploy)
+        {
+            var deployedCatletId = Specification is not null
+                ? Specification.CatletId
+                : Factory.CreateCatletSpecificationsClient().Get(specificationId).Value.CatletId;
+
+            if (!string.IsNullOrEmpty(deployedCatletId))
+            {
+                WriteError(new ErrorRecord(
+                    new InvalidOperationException(
+                        $"The catlet specification is already deployed as catlet {deployedCatletId}. "
+                        + "Re-run with -Redeploy to replace the existing catlet (the existing catlet will be deleted)."),
+                    "CatletSpecificationAlreadyDeployed",
+                    ErrorCategory.ResourceExists,
+                    specificationId));
+                return;
+            }
+        }
+
         var specificationVersion = Factory.CreateCatletSpecificationsClient().GetVersion(
             specificationId,
             specificationVersionId);
@@ -132,54 +151,16 @@ public class SubmitCatletDeployment : CatletConfigCmdlet
         if (!PopulateVariables(variables, Variables, SkipVariablesPrompt, false))
             return;
 
-        Operation operation;
-        try
-        {
-            operation = Factory.CreateCatletSpecificationsClient().Deploy(
+        WaitForCatlet(
+            Factory.CreateCatletSpecificationsClient().Deploy(
                 specificationId,
                 specificationVersionId,
                 new DeployCatletSpecificationRequestBody(variables.ToDictionary(v => v.Name, v => v.Value))
                 {
                     Architecture = Architecture,
                     Redeploy = Redeploy,
-                });
-        }
-        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.Conflict && !Redeploy)
-        {
-            // The specification is already deployed as a catlet. Surface the server's
-            // detail (it names the existing catlet) and point at the actionable fix
-            // instead of leaking the raw HTTP response.
-            var detail = TryGetProblemDetail(ex) ?? "The catlet specification is already deployed.";
-            WriteError(new ErrorRecord(
-                new InvalidOperationException(
-                    $"{detail} Re-run with -Redeploy to replace the existing catlet (the existing catlet will be deleted)."),
-                "CatletSpecificationAlreadyDeployed",
-                ErrorCategory.ResourceExists,
-                specificationId));
-            return;
-        }
-
-        WaitForCatlet(operation, NoWait);
-    }
-
-    // Extracts the 'detail' field of an RFC 9457 problem+json response, if present.
-    private static string TryGetProblemDetail(RequestFailedException ex)
-    {
-        try
-        {
-            var content = ex.GetRawResponse()?.Content;
-            if (content is null)
-                return null;
-
-            using var document = JsonDocument.Parse(content.ToString());
-            return document.RootElement.TryGetProperty("detail", out var detail)
-                ? detail.GetString()
-                : null;
-        }
-        catch
-        {
-            return null;
-        }
+                }),
+            NoWait);
     }
 
     private void WaitForCatlet(Operation operation, bool noWait)

--- a/src/Eryph.ComputeClient.Commands/Catlets/SubmitCatletDeployment.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/SubmitCatletDeployment.cs
@@ -2,9 +2,13 @@
 using System.Collections;
 using System.Linq;
 using System.Management.Automation;
+using System.Net;
+using System.Text.Json;
+using Azure;
 using Eryph.ComputeClient.Models;
 using Eryph.ConfigModel.Json;
 using JetBrains.Annotations;
+using Operation = Eryph.ComputeClient.Models.Operation;
 
 namespace Eryph.ComputeClient.Commands.Catlets;
 
@@ -128,16 +132,54 @@ public class SubmitCatletDeployment : CatletConfigCmdlet
         if (!PopulateVariables(variables, Variables, SkipVariablesPrompt, false))
             return;
 
-        WaitForCatlet(
-            Factory.CreateCatletSpecificationsClient().Deploy(
+        Operation operation;
+        try
+        {
+            operation = Factory.CreateCatletSpecificationsClient().Deploy(
                 specificationId,
                 specificationVersionId,
                 new DeployCatletSpecificationRequestBody(variables.ToDictionary(v => v.Name, v => v.Value))
                 {
                     Architecture = Architecture,
                     Redeploy = Redeploy,
-                }),
-            NoWait);
+                });
+        }
+        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.Conflict && !Redeploy)
+        {
+            // The specification is already deployed as a catlet. Surface the server's
+            // detail (it names the existing catlet) and point at the actionable fix
+            // instead of leaking the raw HTTP response.
+            var detail = TryGetProblemDetail(ex) ?? "The catlet specification is already deployed.";
+            WriteError(new ErrorRecord(
+                new InvalidOperationException(
+                    $"{detail} Re-run with -Redeploy to replace the existing catlet (the existing catlet will be deleted)."),
+                "CatletSpecificationAlreadyDeployed",
+                ErrorCategory.ResourceExists,
+                specificationId));
+            return;
+        }
+
+        WaitForCatlet(operation, NoWait);
+    }
+
+    // Extracts the 'detail' field of an RFC 9457 problem+json response, if present.
+    private static string TryGetProblemDetail(RequestFailedException ex)
+    {
+        try
+        {
+            var content = ex.GetRawResponse()?.Content;
+            if (content is null)
+                return null;
+
+            using var document = JsonDocument.Parse(content.ToString());
+            return document.RootElement.TryGetProperty("detail", out var detail)
+                ? detail.GetString()
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private void WaitForCatlet(Operation operation, bool noWait)

--- a/src/Eryph.ComputeClient.Commands/Catlets/SubmitCatletDeployment.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/SubmitCatletDeployment.cs
@@ -33,6 +33,15 @@ public class SubmitCatletDeployment : CatletConfigCmdlet
         ValueFromPipeline= true)]
     public CatletSpecificationVersion Version { get; set; }
 
+    // Deploy a specification's latest version directly, e.g.
+    // 'Get-CatletSpecification -Name foo | Deploy-Catlet'.
+    [Parameter(
+        ParameterSetName = "Specification",
+        Position = 0,
+        Mandatory = true,
+        ValueFromPipeline = true)]
+    public CatletSpecification Specification { get; set; }
+
     [Parameter]
     public string Architecture { get; set; }
 
@@ -59,8 +68,19 @@ public class SubmitCatletDeployment : CatletConfigCmdlet
 
     protected override void ProcessRecord()
     {
-        var specificationId = Version?.SpecificationId ?? SpecificationId;
-        var specificationVersionId = Version?.Id ?? SpecificationVersionId;
+        if (Specification is not null && Specification.Latest is null)
+        {
+            WriteError(new ErrorRecord(
+                new InvalidOperationException(
+                    $"The catlet specification '{Specification.Name}' does not have any versions to deploy."),
+                "NoVersions",
+                ErrorCategory.ObjectNotFound,
+                Specification));
+            return;
+        }
+
+        var specificationId = Version?.SpecificationId ?? Specification?.Id ?? SpecificationId;
+        var specificationVersionId = Version?.Id ?? Specification?.Latest?.Id ?? SpecificationVersionId;
         if (specificationId is null || specificationVersionId is null)
             return;
 

--- a/test/pester/CatletSpecificationVersion.Tests.ps1
+++ b/test/pester/CatletSpecificationVersion.Tests.ps1
@@ -1,0 +1,81 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+    Pester tests for Get-CatletSpecificationVersion.
+
+    Server-free "parameter surface" tests guarding two fixes:
+      * Issue 1: 'Get-CatletSpecification | Get-CatletSpecificationVersion' must bind the
+        piped specification's 'Id' to -SpecificationId (a CatletSpecification exposes its id
+        as 'Id', not 'SpecificationId'). The version's own id parameter is -VersionId.
+      * Issue 2: -Config emits the version's configuration content as a string.
+
+    The module is imported during Pester's discovery phase. Run via Invoke-PesterTests.ps1,
+    which builds the module first.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+# --- Discovery-time setup: import the freshly built module ---
+$configuration = if ($env:ERYPH_TEST_CONFIGURATION) { $env:ERYPH_TEST_CONFIGURATION } else { 'Debug' }
+$binDir = Join-Path $PSScriptRoot '..' '..' "src/Eryph.ComputeClient.Commands/bin/$configuration"
+$manifest = Get-ChildItem -Path $binDir -Recurse -Filter 'Eryph.ComputeClient.psd1' -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $manifest) {
+    throw "Built module not found under '$binDir'. Build the Commands project first (Invoke-PesterTests.ps1 -Build)."
+}
+Import-Module $manifest.FullName -Force
+
+Describe 'Get-CatletSpecificationVersion parameter surface (no server required)' {
+
+    It 'binds the parent specification id via -SpecificationId (aliased to Id so a piped CatletSpecification binds)' {
+        $p = (Get-Command Get-CatletSpecificationVersion).Parameters['SpecificationId']
+        $p                                                       | Should -Not -BeNullOrEmpty
+        $p.ParameterType                                         | Should -Be ([string])
+        $p.Aliases                                               | Should -Contain 'Id'
+        $p.ParameterSets['list'].ValueFromPipelineByPropertyName | Should -BeTrue
+    }
+
+    It 'exposes the version id as -VersionId (not -Id, which would clash with the spec id)' {
+        $params = (Get-Command Get-CatletSpecificationVersion).Parameters
+        $params.ContainsKey('VersionId')          | Should -BeTrue
+        $params['VersionId'].ParameterType        | Should -Be ([string[]])
+        # The old -Id parameter must be gone; 'Id' is now only an alias of -SpecificationId.
+        $params['SpecificationId'].Aliases        | Should -Contain 'Id'
+    }
+
+    It 'exposes a -Config switch that returns the configuration content as a string' {
+        $cmd = Get-Command Get-CatletSpecificationVersion
+        $cmd.Parameters['Config'].ParameterType   | Should -Be ([switch])
+        # -Config lives in its own output-type set yielding a string (mirrors Get-Catlet -Config).
+        ($cmd.OutputType | ForEach-Object { $_.Type }) | Should -Contain ([string])
+    }
+
+    It '-Config does not require -VersionId (defaults to the latest version) but requires it for the full version object' {
+        $versionId = (Get-Command Get-CatletSpecificationVersion).Parameters['VersionId']
+        # getconfig: optional -> falls back to the specification's latest version.
+        $versionId.ParameterSets['getconfig'].IsMandatory | Should -BeFalse
+        # get: mandatory -> a specific full version object must be addressed explicitly.
+        $versionId.ParameterSets['get'].IsMandatory       | Should -BeTrue
+    }
+}
+
+Describe 'Deploy-Catlet deployment input (no server required)' {
+
+    It 'accepts a piped CatletSpecification (deploy its latest version)' {
+        $p = (Get-Command Submit-CatletDeployment).Parameters['Specification']
+        $p                                | Should -Not -BeNullOrEmpty
+        $p.ParameterType.Name             | Should -Be 'CatletSpecification'
+        $p.ParameterSets.Values.ValueFromPipeline | Should -Contain $true
+    }
+
+    It 'still accepts a piped full CatletSpecificationVersion' {
+        $p = (Get-Command Submit-CatletDeployment).Parameters['Version']
+        $p.ParameterType.Name             | Should -Be 'CatletSpecificationVersion'
+        $p.ParameterSets.Values.ValueFromPipeline | Should -Contain $true
+    }
+
+    It 'still accepts explicit -SpecificationId / -SpecificationVersionId' {
+        $params = (Get-Command Submit-CatletDeployment).Parameters
+        $params['SpecificationId']        | Should -Not -BeNullOrEmpty
+        $params['SpecificationVersionId'] | Should -Not -BeNullOrEmpty
+    }
+}

--- a/test/pester/CatletSpecificationVersion.Tests.ps1
+++ b/test/pester/CatletSpecificationVersion.Tests.ps1
@@ -58,6 +58,17 @@ Describe 'Get-CatletSpecificationVersion parameter surface (no server required)'
     }
 }
 
+Describe 'Get-CatletSpecification -Config (no server required)' {
+
+    It 'exposes a -Config switch that yields the latest version config as a string' {
+        $cmd = Get-Command Get-CatletSpecification
+        $cmd.Parameters['Config'].ParameterType        | Should -Be ([switch])
+        # Available in both addressing modes (by -Id and by -Name).
+        $cmd.Parameters['Config'].ParameterSets.Keys    | Should -Contain '__AllParameterSets'
+        ($cmd.OutputType | ForEach-Object { $_.Type })  | Should -Contain ([string])
+    }
+}
+
 Describe 'Deploy-Catlet deployment input (no server required)' {
 
     It 'accepts a piped CatletSpecification (deploy its latest version)' {


### PR DESCRIPTION
The new `CatletSpecification` cmdlets had two pipelining gaps, an awkward deploy path, and a confusing already-deployed error. This addresses all of them.

**Get-CatletSpecificationVersion**
- `Get-CatletSpecification | Get-CatletSpecificationVersion` now works. A `CatletSpecification` exposes its id as `Id`, so `-SpecificationId` is aliased to `Id` and bound by property name. The version's own id parameter is renamed `-Id` → `-VersionId` to remove the clash (breaking, but these cmdlets are pre-release).
- Adds a `-Config` switch that returns a version's configuration content as a string (mirrors `Get-Catlet -Config`), defaulting to the specification's latest version when no `-VersionId` is given.

**Get-CatletSpecification**
- Adds a `-Config` switch that returns the latest version's configuration content as a string, directly from the specification (e.g. `Get-CatletSpecification -Name foo -Config`).

**Deploy-Catlet / Submit-CatletDeployment**
- Accepts a piped `CatletSpecification` and deploys its latest version, enabling `Get-CatletSpecification -Name foo | Deploy-Catlet`. Existing `Version` / `-SpecificationId` / `-SpecificationVersionId` inputs are unchanged.
- Detects an already-deployed specification up front via its `CatletId` and fails with a clear error pointing at `-Redeploy`, instead of submitting a deployment that the backend rejects with a generic 409 conflict.

Adds server-free Pester parameter-surface tests covering the new bindings.