### PR TITLE
Consume OpenIddict 7 client-assertion preview (ClientRuntime)

### DIFF
--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.9.0" />
+    <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.9.1-PullRequest0066.2" />
     <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.10.0" />
     <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.10.0" />
     <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.10.0" />

--- a/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
+++ b/src/Eryph.ComputeClient.Commands/Eryph.ComputeClient.Commands.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.9.1-PullRequest0066.2" />
+    <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.10.0" />
     <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.10.0" />
     <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.10.0" />
     <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.10.0" />

--- a/src/Eryph.ComputeClient/Eryph.ComputeClient.csproj
+++ b/src/Eryph.ComputeClient/Eryph.ComputeClient.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ClientRuntime.Authentication" Version="0.9.1-PullRequest0066.2" />
+    <PackageReference Include="Eryph.ClientRuntime.Authentication" Version="0.10.0" />
     <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20241108.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Eryph.ComputeClient/Eryph.ComputeClient.csproj
+++ b/src/Eryph.ComputeClient/Eryph.ComputeClient.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ClientRuntime.Authentication" Version="0.9.0" />
+    <PackageReference Include="Eryph.ClientRuntime.Authentication" Version="0.9.1-PullRequest0066.2" />
     <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20241108.1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates the compute-client’s dependency pins to newer Eryph.ClientRuntime packages so authentication can be exercised end-to-end against an eryph server upgraded to OpenIddict 7 (including discovery-driven client-assertion audience negotiation).

Changes:

- Bump Eryph.ClientRuntime.Authentication from 0.9.0 to 0.10.0.
- Bump Eryph.ClientRuntime.Powershell from 0.9.0 to 0.10.0.