### PR TITLE
Migrate to GitVersion 6

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,6 +1,5 @@
 assembly-versioning-scheme: MajorMinor
-mode: ContinuousDeployment
-branches: {}
-ignore:
-  sha: []
-merge-message-formats: {}
+branches:
+  main:
+    deployment-mode: ContinuousDelivery
+    label: ci

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
+    <PackageReference Include="GitVersion.MsBuild" Version="6.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Migrates this repo to GitVersion 6 alongside the build-template change (eryph-org/build#3).

- **GitVersion config** → v6 schema: `deployment-mode: ContinuousDelivery` + `label: ci` under `branches.main` (keeps `X.Y.Z-ci.<n>` for CI builds on `main`).
- **Embedded `GitVersion.MsBuild`** in `src/Directory.Build.props` → `6.7.0`.

Released versions come from named tags, which the pipeline stamps verbatim from the tag name (GitVersion is bypassed for tag builds). Must merge together with the template change.