### PR TITLE
Add guest-services PowerShell cmdlets

### DIFF
--- a/build/Eryph.ComputeClient.Format.ps1xml
+++ b/build/Eryph.ComputeClient.Format.ps1xml
@@ -26,44 +26,52 @@
       </TableControl>
     </View>
     <View>
-      <Name>Eryph.ComputeClient.GuestServiceStatus</Name>
+      <Name>Eryph.ComputeClient.Commands.Catlets.CatletGuestServiceStatus</Name>
       <ViewSelectedBy>
-        <TypeName>Eryph.ComputeClient.GuestServiceStatus</TypeName>
+        <TypeName>Eryph.ComputeClient.Commands.Catlets.CatletGuestServiceStatus</TypeName>
       </ViewSelectedBy>
       <TableControl>
         <TableHeaders>
-          <TableColumnHeader><Label>CatletName</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Name</Label></TableColumnHeader>
           <TableColumnHeader><Label>GuestServicesStatus</Label></TableColumnHeader>
           <TableColumnHeader><Label>GuestServicesVersion</Label></TableColumnHeader>
           <TableColumnHeader><Label>ProvisioningState</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Project</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Id</Label><Width>38</Width></TableColumnHeader>
         </TableHeaders>
         <TableRowEntries>
           <TableRowEntry>
             <TableColumnItems>
-              <TableColumnItem><PropertyName>CatletName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>GuestServicesStatus</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>GuestServicesVersion</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>ProvisioningState</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Project</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Id</PropertyName></TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>
         </TableRowEntries>
       </TableControl>
     </View>
     <View>
-      <Name>Eryph.ComputeClient.GuestServiceConfig</Name>
+      <Name>Eryph.ComputeClient.Commands.Catlets.CatletGuestServiceConfig</Name>
       <ViewSelectedBy>
-        <TypeName>Eryph.ComputeClient.GuestServiceConfig</TypeName>
+        <TypeName>Eryph.ComputeClient.Commands.Catlets.CatletGuestServiceConfig</TypeName>
       </ViewSelectedBy>
       <TableControl>
         <TableHeaders>
-          <TableColumnHeader><Label>CatletName</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Name</Label></TableColumnHeader>
           <TableColumnHeader><Label>Shell</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Project</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Id</Label><Width>38</Width></TableColumnHeader>
         </TableHeaders>
         <TableRowEntries>
           <TableRowEntry>
             <TableColumnItems>
-              <TableColumnItem><PropertyName>CatletName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>Shell</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Project</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Id</PropertyName></TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>
         </TableRowEntries>

--- a/build/Eryph.ComputeClient.Format.ps1xml
+++ b/build/Eryph.ComputeClient.Format.ps1xml
@@ -36,8 +36,6 @@
           <TableColumnHeader><Label>GuestServicesStatus</Label></TableColumnHeader>
           <TableColumnHeader><Label>GuestServicesVersion</Label></TableColumnHeader>
           <TableColumnHeader><Label>ProvisioningState</Label></TableColumnHeader>
-          <TableColumnHeader><Label>Project</Label></TableColumnHeader>
-          <TableColumnHeader><Label>Id</Label><Width>38</Width></TableColumnHeader>
         </TableHeaders>
         <TableRowEntries>
           <TableRowEntry>
@@ -46,8 +44,6 @@
               <TableColumnItem><PropertyName>GuestServicesStatus</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>GuestServicesVersion</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>ProvisioningState</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>Project</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>Id</PropertyName></TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>
         </TableRowEntries>
@@ -62,16 +58,12 @@
         <TableHeaders>
           <TableColumnHeader><Label>Name</Label></TableColumnHeader>
           <TableColumnHeader><Label>Shell</Label></TableColumnHeader>
-          <TableColumnHeader><Label>Project</Label></TableColumnHeader>
-          <TableColumnHeader><Label>Id</Label><Width>38</Width></TableColumnHeader>
         </TableHeaders>
         <TableRowEntries>
           <TableRowEntry>
             <TableColumnItems>
               <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>Shell</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>Project</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>Id</PropertyName></TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>
         </TableRowEntries>

--- a/build/Eryph.ComputeClient.Format.ps1xml
+++ b/build/Eryph.ComputeClient.Format.ps1xml
@@ -26,6 +26,50 @@
       </TableControl>
     </View>
     <View>
+      <Name>Eryph.ComputeClient.GuestServiceStatus</Name>
+      <ViewSelectedBy>
+        <TypeName>Eryph.ComputeClient.GuestServiceStatus</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>CatletName</Label></TableColumnHeader>
+          <TableColumnHeader><Label>GuestServicesStatus</Label></TableColumnHeader>
+          <TableColumnHeader><Label>GuestServicesVersion</Label></TableColumnHeader>
+          <TableColumnHeader><Label>ProvisioningState</Label></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>CatletName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>GuestServicesStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>GuestServicesVersion</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ProvisioningState</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
+      <Name>Eryph.ComputeClient.GuestServiceConfig</Name>
+      <ViewSelectedBy>
+        <TypeName>Eryph.ComputeClient.GuestServiceConfig</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>CatletName</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Shell</Label></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>CatletName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Shell</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
       <Name>Eryph.ComputeClient.Models.Operation</Name>
       <ViewSelectedBy>
         <TypeName>Eryph.ComputeClient.Models.Operation</TypeName>

--- a/build/Eryph.ComputeClient.psd1
+++ b/build/Eryph.ComputeClient.psd1
@@ -101,7 +101,11 @@ CmdletsToExport = @(
     "New-CatletSpecification",
     "Update-CatletSpecification",
     "Remove-CatletSpecification",
-    "Get-CatletSpecificationVersion"
+    "Get-CatletSpecificationVersion",
+    "Get-CatletGuestServiceStatus",
+    "Get-CatletGuestServiceConfig",
+    "Set-CatletGuestServiceConfig",
+    "Remove-CatletGuestServiceAccessKey"
 )
 
 # Variables to export from this module

--- a/src/Eryph.ComputeClient.Commands/Catlets/CatletGuestServiceGetCmdlet.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/CatletGuestServiceGetCmdlet.cs
@@ -1,0 +1,87 @@
+using System.Management.Automation;
+using Eryph.ComputeClient.Models;
+using JetBrains.Annotations;
+
+namespace Eryph.ComputeClient.Commands.Catlets
+{
+    /// <summary>
+    /// Shared base for the read cmdlets that project the guest-services state of a
+    /// catlet. The state is not returned directly: <c>GetGuestServices</c> starts an
+    /// operation whose result carries the agent status, version, provisioning state
+    /// and the configured shell. This base resolves the target catlet(s), runs the
+    /// operation and hands the typed result to the derived cmdlet, which decides which
+    /// part of it to surface (runtime status vs. configuration).
+    /// </summary>
+    [PublicAPI]
+    public abstract class CatletGuestServiceGetCmdlet : CatletCmdLet
+    {
+        [Parameter(
+            ParameterSetName = "get",
+            ValueFromPipeline = true,
+            ValueFromPipelineByPropertyName = true)]
+        public string[] Id { get; set; }
+
+        [Parameter(
+            ParameterSetName = "list",
+            Position = 0)]
+        [ValidateNotNullOrEmpty]
+        public string Name { get; set; }
+
+        [Parameter(
+            ParameterSetName = "list",
+            ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty]
+        public string ProjectName { get; set; }
+
+        protected override void BeginProcessing()
+        {
+            base.BeginProcessing();
+            RequireApiVersion(1, 2, MyInvocation.MyCommand.Name);
+        }
+
+        protected override void ProcessRecord()
+        {
+            if (Id != null)
+            {
+                foreach (var id in Id)
+                {
+                    if (Stopping) break;
+                    if (TryGetById(id, GetSingleCatlet, "catlet", out var catlet))
+                        EmitCatlet(catlet);
+                }
+
+                return;
+            }
+
+            if (!TryGetProjectId(ProjectName, out var projectId))
+                return;
+
+            WriteByNameOrId(
+                Name,
+                GetSingleCatlet,
+                () => Factory.CreateCatletsClient().List(projectId: projectId),
+                catlet => catlet.Name,
+                "catlet",
+                EmitCatlet);
+        }
+
+        private void EmitCatlet(Catlet catlet)
+        {
+            var operation = WaitForOperation(
+                Factory.CreateCatletsClient().GetGuestServices(catlet.Id));
+
+            if (operation.Status != OperationStatus.Completed)
+                return;
+
+            if (operation.Result is not GuestServicesStatusOperationResult result)
+                return;
+
+            WriteResult(catlet, result);
+        }
+
+        /// <summary>
+        /// Projects the part of the guest-services result this cmdlet is responsible for.
+        /// </summary>
+        protected abstract void WriteResult(Catlet catlet, GuestServicesStatusOperationResult result);
+    }
+}

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletGuestServiceConfigCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletGuestServiceConfigCommand.cs
@@ -6,7 +6,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
 {
     [PublicAPI]
     [Cmdlet(VerbsCommon.Get, "CatletGuestServiceConfig", DefaultParameterSetName = "list")]
-    [OutputType(typeof(PSObject))]
+    [OutputType(typeof(CatletGuestServiceConfig))]
     public class GetCatletGuestServiceConfigCommand : CatletGuestServiceGetCmdlet
     {
         // Reports the guest-services configuration. Only the shell is readable: the
@@ -14,12 +14,25 @@ namespace Eryph.ComputeClient.Commands.Catlets
         // so ShellArgs can be set (Set-CatletGuestServiceConfig) but not read back here.
         protected override void WriteResult(Catlet catlet, GuestServicesStatusOperationResult result)
         {
-            var output = new PSObject();
-            output.TypeNames.Insert(0, "Eryph.ComputeClient.GuestServiceConfig");
-            output.Properties.Add(new PSNoteProperty("CatletId", catlet.Id));
-            output.Properties.Add(new PSNoteProperty("CatletName", catlet.Name));
-            output.Properties.Add(new PSNoteProperty("Shell", result.Shell));
-            WriteObject(output);
+            WriteObject(new CatletGuestServiceConfig
+            {
+                Id = catlet.Id,
+                Name = catlet.Name,
+                Project = catlet.Project?.Name,
+                Shell = result.Shell,
+            });
         }
+    }
+
+    [PublicAPI]
+    public class CatletGuestServiceConfig
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Project { get; set; }
+
+        public string Shell { get; set; }
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletGuestServiceConfigCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletGuestServiceConfigCommand.cs
@@ -1,0 +1,25 @@
+using System.Management.Automation;
+using Eryph.ComputeClient.Models;
+using JetBrains.Annotations;
+
+namespace Eryph.ComputeClient.Commands.Catlets
+{
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Get, "CatletGuestServiceConfig", DefaultParameterSetName = "list")]
+    [OutputType(typeof(PSObject))]
+    public class GetCatletGuestServiceConfigCommand : CatletGuestServiceGetCmdlet
+    {
+        // Reports the guest-services configuration. Only the shell is readable: the
+        // GetGuestServices result echoes the configured Shell override but not ShellArgs,
+        // so ShellArgs can be set (Set-CatletGuestServiceConfig) but not read back here.
+        protected override void WriteResult(Catlet catlet, GuestServicesStatusOperationResult result)
+        {
+            var output = new PSObject();
+            output.TypeNames.Insert(0, "Eryph.ComputeClient.GuestServiceConfig");
+            output.Properties.Add(new PSNoteProperty("CatletId", catlet.Id));
+            output.Properties.Add(new PSNoteProperty("CatletName", catlet.Name));
+            output.Properties.Add(new PSNoteProperty("Shell", result.Shell));
+            WriteObject(output);
+        }
+    }
+}

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletGuestServiceStatusCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletGuestServiceStatusCommand.cs
@@ -1,0 +1,26 @@
+using System.Management.Automation;
+using Eryph.ComputeClient.Models;
+using JetBrains.Annotations;
+
+namespace Eryph.ComputeClient.Commands.Catlets
+{
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Get, "CatletGuestServiceStatus", DefaultParameterSetName = "list")]
+    [OutputType(typeof(PSObject))]
+    public class GetCatletGuestServiceStatusCommand : CatletGuestServiceGetCmdlet
+    {
+        // Reports only the runtime state reported by the guest agent. The configured
+        // shell is configuration, not status, and is surfaced by Get-CatletGuestServiceConfig.
+        protected override void WriteResult(Catlet catlet, GuestServicesStatusOperationResult result)
+        {
+            var output = new PSObject();
+            output.TypeNames.Insert(0, "Eryph.ComputeClient.GuestServiceStatus");
+            output.Properties.Add(new PSNoteProperty("CatletId", catlet.Id));
+            output.Properties.Add(new PSNoteProperty("CatletName", catlet.Name));
+            output.Properties.Add(new PSNoteProperty("GuestServicesStatus", result.GuestServicesStatus));
+            output.Properties.Add(new PSNoteProperty("GuestServicesVersion", result.GuestServicesVersion));
+            output.Properties.Add(new PSNoteProperty("ProvisioningState", result.ProvisioningState));
+            WriteObject(output);
+        }
+    }
+}

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletGuestServiceStatusCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletGuestServiceStatusCommand.cs
@@ -6,21 +6,38 @@ namespace Eryph.ComputeClient.Commands.Catlets
 {
     [PublicAPI]
     [Cmdlet(VerbsCommon.Get, "CatletGuestServiceStatus", DefaultParameterSetName = "list")]
-    [OutputType(typeof(PSObject))]
+    [OutputType(typeof(CatletGuestServiceStatus))]
     public class GetCatletGuestServiceStatusCommand : CatletGuestServiceGetCmdlet
     {
         // Reports only the runtime state reported by the guest agent. The configured
         // shell is configuration, not status, and is surfaced by Get-CatletGuestServiceConfig.
         protected override void WriteResult(Catlet catlet, GuestServicesStatusOperationResult result)
         {
-            var output = new PSObject();
-            output.TypeNames.Insert(0, "Eryph.ComputeClient.GuestServiceStatus");
-            output.Properties.Add(new PSNoteProperty("CatletId", catlet.Id));
-            output.Properties.Add(new PSNoteProperty("CatletName", catlet.Name));
-            output.Properties.Add(new PSNoteProperty("GuestServicesStatus", result.GuestServicesStatus));
-            output.Properties.Add(new PSNoteProperty("GuestServicesVersion", result.GuestServicesVersion));
-            output.Properties.Add(new PSNoteProperty("ProvisioningState", result.ProvisioningState));
-            WriteObject(output);
+            WriteObject(new CatletGuestServiceStatus
+            {
+                Id = catlet.Id,
+                Name = catlet.Name,
+                Project = catlet.Project?.Name,
+                GuestServicesStatus = result.GuestServicesStatus,
+                GuestServicesVersion = result.GuestServicesVersion,
+                ProvisioningState = result.ProvisioningState,
+            });
         }
+    }
+
+    [PublicAPI]
+    public class CatletGuestServiceStatus
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Project { get; set; }
+
+        public string GuestServicesStatus { get; set; }
+
+        public string GuestServicesVersion { get; set; }
+
+        public string ProvisioningState { get; set; }
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletGuestServiceAccessKeyCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletGuestServiceAccessKeyCommand.cs
@@ -7,7 +7,7 @@ namespace Eryph.ComputeClient.Commands.Catlets
 {
     [PublicAPI]
     [Cmdlet(VerbsCommon.Remove, "CatletGuestServiceAccessKey", DefaultParameterSetName = "Wait")]
-    [OutputType(typeof(Catlet))]
+    [OutputType(typeof(Catlet), ParameterSetName = new[] { "Wait" })]
     [OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
     public class RemoveCatletGuestServiceAccessKeyCommand : CatletCmdLet
     {

--- a/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletGuestServiceAccessKeyCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/RemoveCatletGuestServiceAccessKeyCommand.cs
@@ -1,0 +1,93 @@
+using System.Management.Automation;
+using Eryph.ComputeClient.Models;
+using JetBrains.Annotations;
+using Operation = Eryph.ComputeClient.Models.Operation;
+
+namespace Eryph.ComputeClient.Commands.Catlets
+{
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Remove, "CatletGuestServiceAccessKey", DefaultParameterSetName = "Wait")]
+    [OutputType(typeof(Catlet))]
+    [OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
+    public class RemoveCatletGuestServiceAccessKeyCommand : CatletCmdLet
+    {
+        [Parameter(
+            Position = 0,
+            ValueFromPipeline = true,
+            Mandatory = true,
+            ValueFromPipelineByPropertyName = true)]
+        [Alias("Name")]
+        public string[] Id { get; set; }
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string ProjectName { get; set; }
+
+        [Parameter]
+        public SwitchParameter Force
+        {
+            get => _force;
+            set => _force = value;
+        }
+
+        /// <summary>
+        /// Returns the catlet whose access key was revoked. By default this cmdlet
+        /// produces no output.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter PassThru
+        {
+            get => _passThru;
+            set => _passThru = value;
+        }
+
+        [Parameter(ParameterSetName = "NoWait")]
+        public SwitchParameter NoWait
+        {
+            get => _nowait;
+            set => _nowait = value;
+        }
+
+        private bool _force;
+        private bool _nowait;
+        private bool _passThru;
+        private bool _yesToAll, _noToAll;
+
+        protected override void BeginProcessing()
+        {
+            base.BeginProcessing();
+            RequireApiVersion(1, 2, "Remove-CatletGuestServiceAccessKey");
+        }
+
+        protected override void ProcessRecord()
+        {
+            foreach (var nameOrId in Id)
+            {
+                foreach (var catlet in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatlet,
+                             projectId => Factory.CreateCatletsClient().List(projectId: projectId), c => c.Name, "catlet"))
+                {
+                    if (Stopping) break;
+
+                    if (!Force && !ShouldContinue(
+                            $"The caller's guest-services access key for catlet '{catlet.Name}' (Id:{catlet.Id}) will be revoked!",
+                            "Warning!", ref _yesToAll, ref _noToAll))
+                    {
+                        continue;
+                    }
+
+                    // Revokes only the caller's own authorized SSH key; the catlet itself
+                    // is unchanged, so we do not emit it unless -PassThru is requested.
+                    Operation operation = Factory.CreateCatletsClient().RemoveAccessKey(catlet.Id);
+
+                    if (_nowait)
+                        WriteObject(operation);
+                    else
+                        WaitForOperation(operation);
+
+                    if (_passThru)
+                        WriteObject(catlet);
+                }
+            }
+        }
+    }
+}

--- a/src/Eryph.ComputeClient.Commands/Catlets/SetCatletGuestServiceConfigCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/SetCatletGuestServiceConfigCommand.cs
@@ -1,0 +1,113 @@
+using System.Management.Automation;
+using Eryph.ComputeClient.Models;
+using JetBrains.Annotations;
+using Operation = Eryph.ComputeClient.Models.Operation;
+
+namespace Eryph.ComputeClient.Commands.Catlets
+{
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Set, "CatletGuestServiceConfig", DefaultParameterSetName = "Wait")]
+    [OutputType(typeof(Catlet), ParameterSetName = new[] { "Wait" })]
+    [OutputType(typeof(Operation), ParameterSetName = new[] { "NoWait" })]
+    public class SetCatletGuestServiceConfigCommand : CatletCmdLet
+    {
+        [Parameter(
+            Position = 0,
+            ValueFromPipeline = true,
+            Mandatory = true,
+            ValueFromPipelineByPropertyName = true)]
+        [Alias("Name")]
+        public string[] Id { get; set; }
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string ProjectName { get; set; }
+
+        /// <summary>
+        /// Shell command for interactive SSH sessions. An empty string clears the
+        /// override; omitting the parameter leaves the current value unchanged.
+        /// </summary>
+        [Parameter]
+        [AllowEmptyString]
+        public string Shell { get; set; }
+
+        /// <summary>
+        /// Arguments for the shell command. Same empty/omitted semantics as <see cref="Shell"/>.
+        /// </summary>
+        [Parameter]
+        [AllowEmptyString]
+        public string ShellArgs { get; set; }
+
+        [Parameter]
+        public SwitchParameter Force
+        {
+            get => _force;
+            set => _force = value;
+        }
+
+        [Parameter(ParameterSetName = "NoWait")]
+        public SwitchParameter NoWait
+        {
+            get => _nowait;
+            set => _nowait = value;
+        }
+
+        private bool _force;
+        private bool _nowait;
+        private bool _yesToAll, _noToAll;
+
+        private bool _shellBound;
+        private bool _shellArgsBound;
+
+        protected override void BeginProcessing()
+        {
+            base.BeginProcessing();
+            RequireApiVersion(1, 2, "Set-CatletGuestServiceConfig");
+
+            _shellBound = MyInvocation.BoundParameters.ContainsKey(nameof(Shell));
+            _shellArgsBound = MyInvocation.BoundParameters.ContainsKey(nameof(ShellArgs));
+
+            if (!_shellBound && !_shellArgsBound)
+            {
+                ThrowTerminatingError(new ErrorRecord(
+                    new PSArgumentException(
+                        "Specify at least one setting to change: -Shell and/or -ShellArgs. "
+                        + "Pass an empty string to clear a setting."),
+                    "NoGuestServiceSettingSpecified",
+                    ErrorCategory.InvalidArgument,
+                    null));
+            }
+        }
+
+        protected override void ProcessRecord()
+        {
+            foreach (var nameOrId in Id)
+            {
+                foreach (var catlet in ResolveActionTargets(nameOrId, ProjectName, GetSingleCatlet,
+                             projectId => Factory.CreateCatletsClient().List(projectId: projectId), c => c.Name, "catlet"))
+                {
+                    if (Stopping) break;
+
+                    if (!Force && !ShouldContinue(
+                            $"The guest-services configuration of catlet '{catlet.Name}' (Id:{catlet.Id}) will be updated!",
+                            "Warning!", ref _yesToAll, ref _noToAll))
+                    {
+                        continue;
+                    }
+
+                    // A null field is left unchanged by the server; only send the values
+                    // the caller actually specified (an empty string clears the override).
+                    var body = new GuestServicesSettingsBody();
+                    if (_shellBound)
+                        body.Shell = Shell;
+                    if (_shellArgsBound)
+                        body.ShellArgs = ShellArgs;
+
+                    WaitForOperation(
+                        Factory.CreateCatletsClient().SetGuestServicesSettings(catlet.Id, body),
+                        _nowait, false, catlet.Id);
+                }
+            }
+        }
+    }
+}

--- a/src/Eryph.ComputeClient.Commands/Catlets/SetCatletGuestServiceConfigCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/SetCatletGuestServiceConfigCommand.cs
@@ -95,8 +95,9 @@ namespace Eryph.ComputeClient.Commands.Catlets
                         continue;
                     }
 
-                    // A null field is left unchanged by the server; only send the values
-                    // the caller actually specified (an empty string clears the override).
+                    // Only the settings the caller specified are sent. An unset property
+                    // stays null and is omitted from the request, so the server leaves it
+                    // unchanged; an empty string is sent and clears the override.
                     var body = new GuestServicesSettingsBody();
                     if (_shellBound)
                         body.Shell = Shell;


### PR DESCRIPTION
Adds PowerShell cmdlets for the catlet guest-services API (compute API 1.2), keeping runtime status and configuration as separate concerns:

- `Get-CatletGuestServiceStatus` — agent status, version, provisioning state
- `Get-CatletGuestServiceConfig` — the configured SSH session shell
- `Set-CatletGuestServiceConfig` — set the shell / shell args
- `Remove-CatletGuestServiceAccessKey` — revoke the caller's SSH access key

The two Get cmdlets share a base (`CatletGuestServiceGetCmdlet`) that runs the single `GetGuestServices` operation and project different fields, so status no longer reports the shell. All cmdlets are gated on API version 1.2 and registered in the module manifest, with table views for the status/config outputs.

Channel management (add access key, SSH channel connect) is intentionally out of scope. Listing authorized keys is not implemented because the compute API exposes no endpoint for it; key add/remove are self-scoped to the caller by design.