### PR TITLE
Add Get-CatletProvisioningStatus and Get-CatletProvisioningLog cmdlets

### DIFF
--- a/build/Eryph.ComputeClient.Format.ps1xml
+++ b/build/Eryph.ComputeClient.Format.ps1xml
@@ -96,12 +96,13 @@
       </TableControl>
     </View>
     <View>
-      <Name>Eryph.ComputeClient.Models.ProvisioningLogEntry</Name>
+      <Name>Eryph.ComputeClient.Commands.Catlets.CatletProvisioningLogEntry</Name>
       <ViewSelectedBy>
-        <TypeName>Eryph.ComputeClient.Models.ProvisioningLogEntry</TypeName>
+        <TypeName>Eryph.ComputeClient.Commands.Catlets.CatletProvisioningLogEntry</TypeName>
       </ViewSelectedBy>
       <TableControl>
         <TableHeaders>
+          <TableColumnHeader><Label>Catlet</Label></TableColumnHeader>
           <TableColumnHeader><Label>Timestamp</Label></TableColumnHeader>
           <TableColumnHeader><Label>Type</Label></TableColumnHeader>
           <TableColumnHeader><Label>Name</Label></TableColumnHeader>
@@ -111,6 +112,7 @@
         <TableRowEntries>
           <TableRowEntry>
             <TableColumnItems>
+              <TableColumnItem><PropertyName>CatletName</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>Timestamp</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>Type</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>

--- a/build/Eryph.ComputeClient.Format.ps1xml
+++ b/build/Eryph.ComputeClient.Format.ps1xml
@@ -72,6 +72,56 @@
       </TableControl>
     </View>
     <View>
+      <Name>Eryph.ComputeClient.Commands.Catlets.CatletProvisioningStatusInfo</Name>
+      <ViewSelectedBy>
+        <TypeName>Eryph.ComputeClient.Commands.Catlets.CatletProvisioningStatusInfo</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>Name</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Status</Label></TableColumnHeader>
+          <TableColumnHeader><Label>ProvisioningStatus</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Project</Label></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Status</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ProvisioningStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Project</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
+      <Name>Eryph.ComputeClient.Models.ProvisioningLogEntry</Name>
+      <ViewSelectedBy>
+        <TypeName>Eryph.ComputeClient.Models.ProvisioningLogEntry</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>Timestamp</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Type</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Name</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Result</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Message</Label></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>Timestamp</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Type</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Result</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Message</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
       <Name>Eryph.ComputeClient.Models.Operation</Name>
       <ViewSelectedBy>
         <TypeName>Eryph.ComputeClient.Models.Operation</TypeName>

--- a/build/Eryph.ComputeClient.psd1
+++ b/build/Eryph.ComputeClient.psd1
@@ -106,7 +106,9 @@ CmdletsToExport = @(
     "Get-CatletGuestServiceStatus",
     "Get-CatletGuestServiceConfig",
     "Set-CatletGuestServiceConfig",
-    "Remove-CatletGuestServiceAccessKey"
+    "Remove-CatletGuestServiceAccessKey",
+    "Get-CatletProvisioningStatus",
+    "Get-CatletProvisioningLog"
 )
 
 # Variables to export from this module

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletProvisioningLogCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletProvisioningLogCommand.cs
@@ -1,0 +1,100 @@
+using System.Management.Automation;
+using Eryph.ComputeClient.Models;
+using JetBrains.Annotations;
+
+namespace Eryph.ComputeClient.Commands.Catlets
+{
+    /// <summary>
+    /// Reads the catlet's provisioning log, reassembled from the guest's cloud-init
+    /// telemetry. The log is not returned directly: <c>GetProvisioningLog</c> starts an
+    /// operation whose result carries both a rendered, human-readable text log and the
+    /// structured events. By default the structured <see cref="ProvisioningLogEntry"/>
+    /// events are written to the pipeline; <c>-AsText</c> emits the text log instead.
+    /// </summary>
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Get, "CatletProvisioningLog", DefaultParameterSetName = "list")]
+    [OutputType(typeof(ProvisioningLogEntry))]
+    [OutputType(typeof(string))]
+    public class GetCatletProvisioningLogCommand : CatletCmdLet
+    {
+        [Parameter(
+            ParameterSetName = "get",
+            ValueFromPipeline = true,
+            ValueFromPipelineByPropertyName = true)]
+        public string[] Id { get; set; }
+
+        [Parameter(
+            ParameterSetName = "list",
+            Position = 0)]
+        [ValidateNotNullOrEmpty]
+        public string Name { get; set; }
+
+        [Parameter(
+            ParameterSetName = "list",
+            ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty]
+        public string ProjectName { get; set; }
+
+        /// <summary>
+        /// Emit the rendered, human-readable text log instead of the structured events.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter AsText { get; set; }
+
+        protected override void BeginProcessing()
+        {
+            base.BeginProcessing();
+            RequireApiVersion(1, 2, MyInvocation.MyCommand.Name);
+        }
+
+        protected override void ProcessRecord()
+        {
+            if (Id != null)
+            {
+                foreach (var id in Id)
+                {
+                    if (Stopping) break;
+                    if (TryGetById(id, GetSingleCatlet, "catlet", out var catlet))
+                        EmitLog(catlet);
+                }
+
+                return;
+            }
+
+            if (!TryGetProjectId(ProjectName, out var projectId))
+                return;
+
+            WriteByNameOrId(
+                Name,
+                GetSingleCatlet,
+                () => Factory.CreateCatletsClient().List(projectId: projectId),
+                catlet => catlet.Name,
+                "catlet",
+                EmitLog);
+        }
+
+        private void EmitLog(Catlet catlet)
+        {
+            var operation = WaitForOperation(
+                Factory.CreateCatletsClient().GetProvisioningLog(catlet.Id));
+
+            if (operation.Status != OperationStatus.Completed)
+                return;
+
+            if (operation.Result is not ProvisioningLogOperationResult result)
+                return;
+
+            if (AsText.IsPresent)
+            {
+                WriteObject(result.RenderedLog);
+                return;
+            }
+
+            foreach (var entry in result.Events)
+            {
+                if (Stopping) break;
+                WriteObject(entry);
+            }
+        }
+    }
+}

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletProvisioningLogCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletProvisioningLogCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Management.Automation;
 using Eryph.ComputeClient.Models;
 using JetBrains.Annotations;
@@ -8,12 +9,14 @@ namespace Eryph.ComputeClient.Commands.Catlets
     /// Reads the catlet's provisioning log, reassembled from the guest's cloud-init
     /// telemetry. The log is not returned directly: <c>GetProvisioningLog</c> starts an
     /// operation whose result carries both a rendered, human-readable text log and the
-    /// structured events. By default the structured <see cref="ProvisioningLogEntry"/>
-    /// events are written to the pipeline; <c>-AsText</c> emits the text log instead.
+    /// structured events. By default the structured events are written to the pipeline
+    /// as <see cref="CatletProvisioningLogEntry"/> objects (each carrying the catlet it
+    /// belongs to, so output stays correlatable when several catlets are targeted);
+    /// <c>-AsText</c> emits the rendered text log instead, prefixed with a catlet header.
     /// </summary>
     [PublicAPI]
     [Cmdlet(VerbsCommon.Get, "CatletProvisioningLog", DefaultParameterSetName = "list")]
-    [OutputType(typeof(ProvisioningLogEntry))]
+    [OutputType(typeof(CatletProvisioningLogEntry))]
     [OutputType(typeof(string))]
     public class GetCatletProvisioningLogCommand : CatletCmdLet
     {
@@ -86,15 +89,52 @@ namespace Eryph.ComputeClient.Commands.Catlets
 
             if (AsText.IsPresent)
             {
-                WriteObject(result.RenderedLog);
+                // Prefix a header so the text blocks stay attributable to their catlet
+                // when several catlets are targeted in one invocation.
+                var header = $"# Catlet {catlet.Name} ({catlet.Id})";
+                WriteObject(header + Environment.NewLine + result.RenderedLog);
                 return;
             }
 
             foreach (var entry in result.Events)
             {
                 if (Stopping) break;
-                WriteObject(entry);
+                WriteObject(new CatletProvisioningLogEntry
+                {
+                    CatletId = catlet.Id,
+                    CatletName = catlet.Name,
+                    Project = catlet.Project?.Name,
+                    Timestamp = entry.Timestamp,
+                    Type = entry.Type,
+                    Name = entry.Name,
+                    Result = entry.Result,
+                    Message = entry.Message,
+                });
             }
         }
+    }
+
+    /// <summary>
+    /// A single provisioning-log event, tagged with the catlet it belongs to so the
+    /// pipeline output can be correlated back to a catlet when several are targeted.
+    /// </summary>
+    [PublicAPI]
+    public class CatletProvisioningLogEntry
+    {
+        public string CatletId { get; set; }
+
+        public string CatletName { get; set; }
+
+        public string Project { get; set; }
+
+        public DateTimeOffset? Timestamp { get; set; }
+
+        public string Type { get; set; }
+
+        public string Name { get; set; }
+
+        public string Result { get; set; }
+
+        public string Message { get; set; }
     }
 }

--- a/src/Eryph.ComputeClient.Commands/Catlets/GetCatletProvisioningStatusCommand.cs
+++ b/src/Eryph.ComputeClient.Commands/Catlets/GetCatletProvisioningStatusCommand.cs
@@ -1,0 +1,96 @@
+using System.Management.Automation;
+using Eryph.ComputeClient.Models;
+using JetBrains.Annotations;
+
+namespace Eryph.ComputeClient.Commands.Catlets
+{
+    /// <summary>
+    /// Reports the catlet's provisioning status. Unlike the guest-services state,
+    /// the provisioning status is carried directly on the catlet resource, so it is
+    /// read straight from <c>Get</c>/<c>List</c> without starting an operation.
+    /// The provisioning status (<see cref="CatletProvisioningStatus"/>) reflects the
+    /// catlet-level provisioning progress and is distinct from the guest agent's own
+    /// provisioning state surfaced by Get-CatletGuestServiceStatus.
+    /// </summary>
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Get, "CatletProvisioningStatus", DefaultParameterSetName = "list")]
+    [OutputType(typeof(CatletProvisioningStatusInfo))]
+    public class GetCatletProvisioningStatusCommand : CatletCmdLet
+    {
+        [Parameter(
+            ParameterSetName = "get",
+            ValueFromPipeline = true,
+            ValueFromPipelineByPropertyName = true)]
+        public string[] Id { get; set; }
+
+        [Parameter(
+            ParameterSetName = "list",
+            Position = 0)]
+        [ValidateNotNullOrEmpty]
+        public string Name { get; set; }
+
+        [Parameter(
+            ParameterSetName = "list",
+            ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty]
+        public string ProjectName { get; set; }
+
+        protected override void BeginProcessing()
+        {
+            base.BeginProcessing();
+            RequireApiVersion(1, 2, MyInvocation.MyCommand.Name);
+        }
+
+        protected override void ProcessRecord()
+        {
+            if (Id != null)
+            {
+                foreach (var id in Id)
+                {
+                    if (Stopping) break;
+                    if (TryGetById(id, GetSingleCatlet, "catlet", out var catlet))
+                        WriteStatus(catlet);
+                }
+
+                return;
+            }
+
+            if (!TryGetProjectId(ProjectName, out var projectId))
+                return;
+
+            WriteByNameOrId(
+                Name,
+                GetSingleCatlet,
+                () => Factory.CreateCatletsClient().List(projectId: projectId),
+                catlet => catlet.Name,
+                "catlet",
+                WriteStatus);
+        }
+
+        private void WriteStatus(Catlet catlet)
+        {
+            WriteObject(new CatletProvisioningStatusInfo
+            {
+                Id = catlet.Id,
+                Name = catlet.Name,
+                Project = catlet.Project?.Name,
+                Status = catlet.Status.ToString(),
+                ProvisioningStatus = catlet.ProvisioningStatus.ToString(),
+            });
+        }
+    }
+
+    [PublicAPI]
+    public class CatletProvisioningStatusInfo
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Project { get; set; }
+
+        public string Status { get; set; }
+
+        public string ProvisioningStatus { get; set; }
+    }
+}


### PR DESCRIPTION
Surface the catlet provisioning status and provisioning log recently added to the compute API.

- **Get-CatletProvisioningStatus** — reads `ProvisioningStatus` directly from the catlet resource (no operation), projected alongside Id/Name/Project/Status. Resolves by `-Id` (pipeline) or `-Name`/`-ProjectName`.
- **Get-CatletProvisioningLog** — runs the provisioning-log operation and emits the structured `ProvisioningLogEntry` events by default, or the rendered text log with `-AsText`.

Both are gated at API version 1.2 (matching the other guest-services cmdlets) and register table views for their output types. `ProvisioningStatus` is available on the `Catlet` output type but intentionally not added to the default `Get-Catlet` table, since it has its own cmdlet.