### PR TITLE
Fix: Sync Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dbosoft-azure-devops-sync.yml
+++ b/.github/workflows/dbosoft-azure-devops-sync.yml
@@ -1,4 +1,6 @@
 name: Sync issue to Azure DevOps
+permissions:
+  contents: read
 on:
   issues:
   issue_comment:


### PR DESCRIPTION
Potential fix for [https://github.com/eryph-org/dotnet-computeclient/security/code-scanning/1](https://github.com/eryph-org/dotnet-computeclient/security/code-scanning/1)

Add an explicit `permissions` block to the workflow file at the top level (root), so it applies to all jobs unless overridden.  
For this workflow, a safe minimal baseline is:

- `contents: read`

This preserves existing functionality for typical issue/comment-triggered orchestration while explicitly limiting token scope. If later the reusable workflow requires extra scopes, those can be added deliberately (for example `issues: write` or `pull-requests: write`), but the immediate CodeQL finding is resolved by defining explicit permissions now.

**File to change:** `.github/workflows/dbosoft-azure-devops-sync.yml`  
**Region to change:** immediately after `name:` and before `on:`  
**No imports/dependencies/methods needed** (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
